### PR TITLE
fixes #67, pads by one frame past last event

### DIFF
--- a/pumpp/task/base.py
+++ b/pumpp/task/base.py
@@ -154,14 +154,15 @@ class BaseTaskTransformer(Scope):
         n_total = int(time_to_frames(duration, sr=self.sr,
                                      hop_length=self.hop_length))
 
-        target = np.empty((n_total, values.shape[1]), dtype=dtype)
+        target = np.empty((max(n_total, 1+int(frames.max())), values.shape[1]),
+                          dtype=dtype)
 
         target.fill(fill_value(dtype))
         values = values.astype(dtype)
         for column, event in zip(values, frames):
             target[event] += column
 
-        return target
+        return target[:n_total]
 
     def encode_intervals(self, duration, intervals, values, dtype=np.bool,
                          multi=True, fill=None):
@@ -205,7 +206,8 @@ class BaseTaskTransformer(Scope):
 
         values = values.astype(dtype)
 
-        target = np.empty((n_total, values.shape[1]), dtype=dtype)
+        target = np.empty((max(n_total, 1+int(frames.max())), values.shape[1]),
+                          dtype=dtype)
 
         target.fill(fill)
 
@@ -215,7 +217,7 @@ class BaseTaskTransformer(Scope):
             else:
                 target[interval[0]:interval[1]] = column
 
-        return target
+        return target[:n_total]
 
     def decode_events(self, encoded):
         '''Decode labeled events into (time, value) pairs

--- a/pumpp/task/base.py
+++ b/pumpp/task/base.py
@@ -154,7 +154,11 @@ class BaseTaskTransformer(Scope):
         n_total = int(time_to_frames(duration, sr=self.sr,
                                      hop_length=self.hop_length))
 
-        target = np.empty((max(n_total, 1+int(frames.max())), values.shape[1]),
+        n_alloc = n_total
+        if np.any(frames):
+            n_alloc = max(n_total, 1 + int(frames.max()))
+
+        target = np.empty((n_alloc, values.shape[1]),
                           dtype=dtype)
 
         target.fill(fill_value(dtype))
@@ -206,7 +210,12 @@ class BaseTaskTransformer(Scope):
 
         values = values.astype(dtype)
 
-        target = np.empty((max(n_total, 1+int(frames.max())), values.shape[1]),
+        n_alloc = n_total
+        if np.any(frames):
+            n_alloc = max(n_total, 1 + int(frames.max()))
+
+        target = np.empty((n_alloc, values.shape[1]),
+
                           dtype=dtype)
 
         target.fill(fill)


### PR DESCRIPTION
This PR modifies the base task transformer to build a possibly over-complete annotation array and then trim down to the duration limit.

This prevents indexerrors when the last event / interval boundary occurs at the end of track.