### PR TITLE
forward-compatibility with jams 0.3

### DIFF
--- a/pumpp/task/chord.py
+++ b/pumpp/task/chord.py
@@ -142,7 +142,7 @@ class ChordTransformer(BaseTaskTransformer):
             sounding.
         '''
         # Construct a blank annotation with mask = 0
-        intervals, chords = ann.data.to_interval_values()
+        intervals, chords = ann.to_interval_values()
 
         # Get the dtype for root/bass
         if self.sparse:
@@ -465,7 +465,7 @@ class ChordTagTransformer(BaseTaskTransformer):
                 A time-varying binary encoding of the chords
         '''
 
-        intervals, values = ann.data.to_interval_values()
+        intervals, values = ann.to_interval_values()
 
         chords = []
         for v in values:

--- a/pumpp/task/event.py
+++ b/pumpp/task/event.py
@@ -60,7 +60,7 @@ class BeatTransformer(BaseTaskTransformer):
 
         mask_downbeat = False
 
-        intervals, values = ann.data.to_interval_values()
+        intervals, values = ann.to_interval_values()
         values = np.asarray(values)
 
         beat_events = intervals[:, 0]

--- a/pumpp/task/regression.py
+++ b/pumpp/task/regression.py
@@ -82,7 +82,8 @@ class VectorTransformer(BaseTaskTransformer):
         DataError
             If the input dimension does not match
         '''
-        vector = np.asarray(ann.data.value.iloc[0], dtype=self.dtype)
+        _, values = ann.to_interval_values()
+        vector = np.asarray(values[0], dtype=self.dtype)
         if len(vector) != self.dimension:
             raise DataError('vector dimension({:0}) '
                             '!= self.dimension({:1})'

--- a/pumpp/task/tags.py
+++ b/pumpp/task/tags.py
@@ -85,7 +85,7 @@ class DynamicLabelTransformer(BaseTaskTransformer):
             data['tags'] : np.ndarray, shape=(n, n_labels)
                 A time-varying binary encoding of the labels
         '''
-        intervals, values = ann.data.to_interval_values()
+        intervals, values = ann.to_interval_values()
 
         # Suppress all intervals not in the encoder
         tags = []
@@ -167,7 +167,7 @@ class StaticLabelTransformer(BaseTaskTransformer):
                 A static binary encoding of the labels
         '''
         intervals = np.asarray([[0, 1]])
-        values = list(ann.data.value)
+        values = list([obs.value for obs in ann])
         intervals = np.tile(intervals, [len(values), 1])
 
         # Suppress all intervals not in the encoder

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     license='ISC',
     install_requires=['six',
                       'librosa>=0.5.0',
-                      'jams>=0.2.2',
+                      'jams>=0.2.3',
                       'scikit-learn>=0.17',
                       'mir_eval>=0.4'],
     extras_require={

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -457,8 +457,8 @@ def test_task_vector_present(target_dimension, data_dimension, name):
                                          name=name)
 
     ann = jams.Annotation(namespace='vector')
-    ann.append(time=0, duration=1,
-               value=list(np.random.randn(data_dimension)))
+    value = list(np.random.randn(data_dimension))
+    ann.append(time=0, duration=1, value=value)
 
     jam.annotations.append(ann)
 
@@ -471,7 +471,7 @@ def test_task_vector_present(target_dimension, data_dimension, name):
     assert output[var_name].shape[1] == target_dimension
 
     # Make sure it's empty
-    assert np.allclose(output[var_name], ann.data.loc[0].value)
+    assert np.allclose(output[var_name], value)
 
     for key in trans.fields:
         assert shape_match(output[key].shape, trans.fields[key].shape)


### PR DESCRIPTION
Implements #69 

This removes direct access of data fields in favor of interval_values/event_values access methods.

Tests pass on 0.2.3 and 0.3.0dev (future PR).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bmcfee/pumpp/70)
<!-- Reviewable:end -->
