### PR TITLE
Confidence rated prediction

### DIFF
--- a/tests/test_decode.py
+++ b/tests/test_decode.py
@@ -250,6 +250,8 @@ def test_decode_chordtag_hard_dense(sr, hop_length, ann_chord):
     data = tc.transform_annotation(ann_chord, ann_chord.duration)
 
     inverse = tc.inverse(data['chord'], duration=ann_chord.duration)
+    for obs in inverse:
+        assert 0 <= obs.confidence <= 1.
     data2 = tc.transform_annotation(inverse, ann_chord.duration)
 
     assert np.allclose(data['chord'], data2['chord'])
@@ -267,6 +269,10 @@ def test_decode_chordtag_soft_dense(sr, hop_length, ann_chord):
 
     chord_predict = data['chord'] * 0.51 + 0.1
     inverse = tc.inverse(chord_predict, duration=ann_chord.duration)
+
+    for obs in inverse:
+        assert 0 <= obs.confidence <= 1.
+
     data2 = tc.transform_annotation(inverse, ann_chord.duration)
 
     assert np.allclose(data['chord'], data2['chord'])
@@ -283,6 +289,8 @@ def test_decode_chordtag_hard_sparse_sparse(sr, hop_length, ann_chord):
     data = tc.transform_annotation(ann_chord, ann_chord.duration)
 
     inverse = tc.inverse(data['chord'], duration=ann_chord.duration)
+    for obs in inverse:
+        assert 0 <= obs.confidence <= 1.
     data2 = tc.transform_annotation(inverse, ann_chord.duration)
 
     assert np.allclose(data['chord'], data2['chord'])
@@ -305,6 +313,8 @@ def test_decode_chordtag_hard_dense_sparse(sr, hop_length, ann_chord):
 
     # Invert using the sparse encoder
     inverse = tcs.inverse(data['chord'], duration=ann_chord.duration)
+    for obs in inverse:
+        assert 0 <= obs.confidence <= 1.
     data2 = tcs.transform_annotation(inverse, ann_chord.duration)
 
     dense_positions = np.where(data['chord'])[1]
@@ -330,6 +340,8 @@ def test_decode_chordtag_soft_dense_sparse(sr, hop_length, ann_chord):
     chord_predict = data['chord'] * 0.51 + 0.1
     # Invert using the sparse encoder
     inverse = tcs.inverse(chord_predict, duration=ann_chord.duration)
+    for obs in inverse:
+        assert 0 <= obs.confidence <= 1.
     data2 = tcs.transform_annotation(inverse, ann_chord.duration)
 
     dense_positions = np.where(data['chord'])[1]

--- a/tests/test_decode.py
+++ b/tests/test_decode.py
@@ -162,6 +162,8 @@ def test_decode_beat_hard(sr, hop_length, ann_beat):
 
     data = tc.transform_annotation(ann_beat, ann_beat.duration)
     inverse = tc.inverse(data['beat'], duration=ann_beat.duration)
+    for obs in inverse:
+        assert 0. <= obs.confidence <= 1.
     data2 = tc.transform_annotation(inverse, ann_beat.duration)
 
     assert np.allclose(data['beat'], data2['beat'])
@@ -175,6 +177,8 @@ def test_decode_beat_soft(sr, hop_length, ann_beat):
     beat_pred = data['beat'] * 0.51 + 0.1
 
     inverse = tc.inverse(beat_pred, duration=ann_beat.duration)
+    for obs in inverse:
+        assert 0. <= obs.confidence <= 1.
     data2 = tc.transform_annotation(inverse, ann_beat.duration)
 
     assert np.allclose(data['beat'], data2['beat'])
@@ -187,6 +191,8 @@ def test_decode_beat_downbeat_hard(sr, hop_length, ann_beat):
     data = tc.transform_annotation(ann_beat, ann_beat.duration)
     inverse = tc.inverse(data['beat'], downbeat=data['downbeat'],
                          duration=ann_beat.duration)
+    for obs in inverse:
+        assert 0. <= obs.confidence <= 1.
     data2 = tc.transform_annotation(inverse, ann_beat.duration)
 
     assert np.allclose(data['beat'], data2['beat'])
@@ -201,6 +207,8 @@ def test_decode_beat_downbeat_soft(sr, hop_length, ann_beat):
     dbeat_pred = data['downbeat'] * 0.51 + 0.1
     inverse = tc.inverse(beat_pred, downbeat=dbeat_pred,
                          duration=ann_beat.duration)
+    for obs in inverse:
+        assert 0. <= obs.confidence <= 1.
     data2 = tc.transform_annotation(inverse, ann_beat.duration)
 
     assert np.allclose(data['beat'], data2['beat'])

--- a/tests/test_decode.py
+++ b/tests/test_decode.py
@@ -101,6 +101,8 @@ def test_decode_tags_dynamic_hard(sr, hop_length, ann_tag):
     data = tc.transform_annotation(ann_tag, ann_tag.duration)
 
     inverse = tc.inverse(data['tags'], duration=ann_tag.duration)
+    for obs in inverse:
+        assert 0. <= obs.confidence <= 1.
     data2 = tc.transform_annotation(inverse, ann_tag.duration)
 
     assert np.allclose(data['tags'], data2['tags'])
@@ -119,6 +121,8 @@ def test_decode_tags_dynamic_soft(sr, hop_length, ann_tag):
     # Soften the data, but preserve the decisions
     tags_predict = data['tags'] * 0.51 + 0.1
     inverse = tc.inverse(tags_predict, duration=ann_tag.duration)
+    for obs in inverse:
+        assert 0. <= obs.confidence <= 1.
     data2 = tc.transform_annotation(inverse, ann_tag.duration)
 
     assert np.allclose(data['tags'], data2['tags'])
@@ -130,6 +134,8 @@ def test_decode_tags_static_hard(ann_tag):
 
     data = tc.transform_annotation(ann_tag, ann_tag.duration)
     inverse = tc.inverse(data['tags'], ann_tag.duration)
+    for obs in inverse:
+        assert 0. <= obs.confidence <= 1.
     data2 = tc.transform_annotation(inverse, ann_tag.duration)
 
     assert np.allclose(data['tags'], data2['tags'])
@@ -143,6 +149,8 @@ def test_decode_tags_static_soft(ann_tag):
     tags_predict = data['tags'] * 0.51 + 0.1
 
     inverse = tc.inverse(tags_predict, ann_tag.duration)
+    for obs in inverse:
+        assert 0. <= obs.confidence <= 1.
     data2 = tc.transform_annotation(inverse, ann_tag.duration)
 
     assert np.allclose(data['tags'], data2['tags'])


### PR DESCRIPTION
#### Reference Issue
Fixes #89 


#### What does this implement/fix? Explain your changes.
Adds confidence predictions to inverse transforms.

- [x] chord-tag
- [x] dynamic tag
- [x] sparse tag
- [x] beat


#### Any other comments?

Confidence is assumed to be the mean of the output, which we assume are generally likelihoods.

Gmean might be more appropriate, but was causing some underflow errors.