### PR TITLE
fixed #95, check data duration before sampling

### DIFF
--- a/pumpp/sampler.py
+++ b/pumpp/sampler.py
@@ -17,7 +17,7 @@ import six
 import numpy as np
 
 from .base import Slicer
-from .exceptions import ParameterError
+from .exceptions import ParameterError, DataError
 
 __all__ = ['Sampler', 'SequentialSampler', 'VariableLengthSampler']
 
@@ -133,6 +133,10 @@ class Sampler(Slicer):
             The start index of a sample patch
         '''
         duration = self.data_duration(data)
+
+        if self.duration > duration:
+            raise DataError('Data duration={} is less than '
+                            'sample duration={}'.format(duration, self.duration))
 
         while True:
             # Generate a sampling interval


### PR DESCRIPTION
#### Reference Issue
Fixes #95 


#### What does this implement/fix? Explain your changes.

Adds a duration check on data in the sampler.  If the data is too short, a `DataError` is thrown.
