### PR TITLE
viterbi decoding

### DIFF
--- a/pumpp/task/base.py
+++ b/pumpp/task/base.py
@@ -340,7 +340,7 @@ class BaseTaskTransformer(Scope):
                 else:
                     encoded_ = viterbi_discriminative(encoded.T, transition,
                                                       p_init=p_init,
-                                                      p_state=p_state)[:, np.newaxis]
+                                                      p_state=p_state)
                     # Map to one-hot encoding
                     encoded = np.zeros(encoded.shape, dtype=bool)
                     encoded[np.arange(len(encoded_)), encoded_] = True

--- a/pumpp/task/beat.py
+++ b/pumpp/task/beat.py
@@ -5,6 +5,7 @@
 import numpy as np
 
 from librosa import time_to_frames
+from librosa.sequence import transition_loop, transition_cycle
 import jams
 from mir_eval.util import boundaries_to_intervals, adjust_intervals
 from sklearn.preprocessing import LabelBinarizer, LabelEncoder
@@ -28,11 +29,67 @@ class BeatTransformer(BaseTaskTransformer):
 
     hop_length : int > 0
         The hop length for annotation frames
+
+    p_self_beat : None, float in (0, 1), or np.ndarray [shape=(2,)]
+        Optional self-loop probability(ies), used for Viterbi decoding
+
+    p_state_beat : None or float in (0, 1)
+        Optional marginal probability for beat state
+
+    p_init_beat : None or float in (0, 1)
+        Optional initial probability for beat state
+
+    p_self_down : None, float in (0, 1), or np.ndarray [shape=(2,)]
+        Optional self-loop probability(ies), used for Viterbi decoding
+
+    p_state_down : None or float in (0, 1)
+        Optional marginal probability for downbeat state
+
+    p_init_down : None or float in (0, 1)
+        Optional initial probability for downbeat state
+
     '''
-    def __init__(self, name='beat', sr=22050, hop_length=512):
+    def __init__(self, name='beat', sr=22050, hop_length=512,
+                 p_self_beat=None, p_init_beat=None, p_state_beat=None,
+                 p_self_down=None, p_init_down=None, p_state_down=None):
+
         super(BeatTransformer, self).__init__(name=name,
                                               namespace='beat',
                                               sr=sr, hop_length=hop_length)
+
+        if p_self_beat is None:
+            self.beat_transition = None
+        else:
+            self.beat_transition = transition_loop(2, p_self_beat)
+
+        if p_init_beat is not None:
+            if not np.isscalar(p_init_beat):
+                raise ParameterError('Invalid p_init_beat={}'.format(p_init_beat))
+
+        self.beat_p_init = p_init_beat
+
+        if p_state_beat is not None:
+            if not np.isscalar(p_state_beat):
+                raise ParameterError('Invalid p_state_beat={}'.format(p_state_beat))
+
+        self.beat_p_state = p_state_beat
+
+        if p_self_down is None:
+            self.down_transition = None
+        else:
+            self.down_transition = transition_loop(2, p_self_down)
+
+        if p_init_down is not None:
+            if not np.isscalar(p_init_down):
+                raise ParameterError('Invalid p_init_down={}'.format(p_init_down))
+
+        self.down_p_init = p_init_down
+
+        if p_state_down is not None:
+            if not np.isscalar(p_state_down):
+                raise ParameterError('Invalid p_state_down={}'.format(p_state_down))
+
+        self.down_p_state = p_state_down
 
         self.register('beat', [None], np.bool)
         self.register('downbeat', [None], np.bool)
@@ -96,14 +153,19 @@ class BeatTransformer(BaseTaskTransformer):
 
         ann = jams.Annotation(namespace=self.namespace, duration=duration)
 
-        beat_times = np.asarray([t for t, _ in self.decode_events(encoded) if _])
+        beat_times = np.asarray([t for t, _ in self.decode_events(encoded,
+                                                                  transition=self.beat_transition,
+                                                                  p_init=self.beat_p_init,
+                                                                  p_state=self.beat_p_state) if _])
         beat_frames = time_to_frames(beat_times,
                                      sr=self.sr,
                                      hop_length=self.hop_length)
 
         if downbeat is not None:
-            downbeat_times = set([t for t, _ in self.decode_events(downbeat)
-                                  if _])
+            downbeat_times = set([t for t, _ in self.decode_events(downbeat,
+                                                                   transition=self.down_transition,
+                                                                   p_init=self.down_p_init,
+                                                                   p_state=self.down_p_state) if _])
             pickup_beats = len([t for t in beat_times
                                 if t < min(downbeat_times)])
         else:
@@ -160,6 +222,11 @@ class BeatPositionTransformer(BaseTaskTransformer):
             self.encoder = LabelBinarizer()
         self.encoder.fit(labels)
         self._classes = set(self.encoder.classes_)
+
+        # transitions should use transition_loop here
+        #   construct block-wise for each metrical length
+        # initial-state distributions should be over X
+        #   X -> **/01 s
 
         if self.sparse:
             self.register('position', [None, 1], np.int)

--- a/pumpp/task/beat.py
+++ b/pumpp/task/beat.py
@@ -57,10 +57,7 @@ class BeatTransformer(BaseTaskTransformer):
                                               namespace='beat',
                                               sr=sr, hop_length=hop_length)
 
-        if p_self_beat is None:
-            self.beat_transition = None
-        else:
-            self.beat_transition = transition_loop(2, p_self_beat)
+        self.set_transition_beat(p_self_beat)
 
         if p_init_beat is not None:
             if not np.isscalar(p_init_beat):
@@ -74,10 +71,7 @@ class BeatTransformer(BaseTaskTransformer):
 
         self.beat_p_state = p_state_beat
 
-        if p_self_down is None:
-            self.down_transition = None
-        else:
-            self.down_transition = transition_loop(2, p_self_down)
+        self.set_transition_down(p_self_beat)
 
         if p_init_down is not None:
             if not np.isscalar(p_init_down):
@@ -94,6 +88,34 @@ class BeatTransformer(BaseTaskTransformer):
         self.register('beat', [None], np.bool)
         self.register('downbeat', [None], np.bool)
         self.register('mask_downbeat', [1], np.bool)
+
+    def set_transition_beat(self, p_self):
+        '''Set the beat-tracking transition matrix according to
+        self-loop probabilities.
+
+        Parameters
+        ----------
+        p_self : None, float in (0, 1), or np.ndarray [shape=(2,)]
+            Optional self-loop probability(ies), used for Viterbi decoding
+        '''
+        if p_self is None:
+            self.beat_transition = None
+        else:
+            self.beat_transition = transition_loop(2, p_self)
+
+    def set_transition_down(self, p_self):
+        '''Set the downbeat-tracking transition matrix according to
+        self-loop probabilities.
+
+        Parameters
+        ----------
+        p_self : None, float in (0, 1), or np.ndarray [shape=(2,)]
+            Optional self-loop probability(ies), used for Viterbi decoding
+        '''
+        if p_self is None:
+            self.down_transition = None
+        else:
+            self.down_transition = transition_loop(2, p_self)
 
     def transform_annotation(self, ann, duration):
         '''Apply the beat transformer

--- a/pumpp/task/chord.py
+++ b/pumpp/task/chord.py
@@ -381,10 +381,7 @@ class ChordTagTransformer(BaseTaskTransformer):
         self.encoder.fit(labels)
         self._classes = set(self.encoder.classes_)
 
-        if p_self is None:
-            self.transition = None
-        else:
-            self.transition = transition_loop(len(self._classes), p_self)
+        self.set_transition(p_self)
 
         if p_init is not None:
             if len(p_init) != len(self._classes):
@@ -415,6 +412,19 @@ class ChordTagTransformer(BaseTaskTransformer):
             self.register('chord', [None, 1], np.int)
         else:
             self.register('chord', [None, len(self._classes)], np.bool)
+
+    def set_transition(self, p_self):
+        '''Set the transition matrix according to self-loop probabilities.
+
+        Parameters
+        ----------
+        p_self : None, float in (0, 1), or np.ndarray [shape=(n_labels,)]
+            Optional self-loop probability(ies), used for Viterbi decoding
+        '''
+        if p_self is None:
+            self.transition = None
+        else:
+            self.transition = transition_loop(len(self._classes), p_self)
 
     def empty(self, duration):
         '''Empty chord annotations

--- a/pumpp/task/tags.py
+++ b/pumpp/task/tags.py
@@ -6,6 +6,7 @@ import numpy as np
 from sklearn.preprocessing import MultiLabelBinarizer
 
 from librosa import time_to_frames
+from librosa.sequence import transition_loop
 
 import jams
 
@@ -72,8 +73,8 @@ class DynamicLabelTransformer(BaseTaskTransformer):
             if np.isscalar(p_self):
                 p_self = p_self * np.ones(len(self._classes))
 
-            for i in range(self._classes):
-                self.transition[i] = librosa.sequence.transition_loop(2, p_self[i])
+            for i in range(len(self._classes)):
+                self.transition[i] = transition_loop(2, p_self[i])
 
         if p_init is not None:
             if len(p_init) != len(self._classes):

--- a/pumpp/task/tags.py
+++ b/pumpp/task/tags.py
@@ -11,6 +11,7 @@ from librosa.sequence import transition_loop
 import jams
 
 from .base import BaseTaskTransformer
+from ..exceptions import ParameterError
 
 __all__ = ['DynamicLabelTransformer', 'StaticLabelTransformer']
 
@@ -73,23 +74,23 @@ class DynamicLabelTransformer(BaseTaskTransformer):
             if np.isscalar(p_self):
                 self.transition = transition_loop(2, p_self)
             elif len(p_self) != len(self._classes):
-                raise ParameterError('Invalid p_self.shape={} for vocabulary {} size={}'.format(p_self.shape, vocab, len(self._classes)))
+                raise ParameterError('Invalid p_self.shape={} for vocabulary size={}'.format(p_self.shape, len(self._classes)))
             else:
                 for i in range(len(self._classes)):
                     self.transition[i] = transition_loop(2, p_self[i])
 
         if p_init is not None:
             if len(p_init) != len(self._classes):
-                raise ParameterError('Invalid p_init.shape={} for vocabulary {} size={}'.format(p_init.shape, vocab, len(self._classes)))
+                raise ParameterError('Invalid p_init.shape={} for vocabulary size={}'.format(p_init.shape, len(self._classes)))
 
         self.p_init = p_init
 
         if p_state is not None:
             if len(p_state) != len(self._classes):
-                raise ParameterError('Invalid p_state.shape={} for vocabulary {} size={}'.format(p_state.shape, vocab, len(self._classes)))
+                raise ParameterError('Invalid p_state.shape={} for vocabulary size={}'.format(p_state.shape, len(self._classes)))
 
         self.p_state = p_state
-        
+
         self.register('tags', [None, len(self._classes)], np.bool)
 
     def empty(self, duration):

--- a/pumpp/task/tags.py
+++ b/pumpp/task/tags.py
@@ -71,10 +71,12 @@ class DynamicLabelTransformer(BaseTaskTransformer):
         else:
             self.transition = np.empty((len(self._classes), 2, 2))
             if np.isscalar(p_self):
-                p_self = p_self * np.ones(len(self._classes))
-
-            for i in range(len(self._classes)):
-                self.transition[i] = transition_loop(2, p_self[i])
+                self.transition = transition_loop(2, p_self)
+            elif len(p_self) != len(self._classes):
+                raise ParameterError('Invalid p_self.shape={} for vocabulary {} size={}'.format(p_self.shape, vocab, len(self._classes)))
+            else:
+                for i in range(len(self._classes)):
+                    self.transition[i] = transition_loop(2, p_self[i])
 
         if p_init is not None:
             if len(p_init) != len(self._classes):

--- a/setup.py
+++ b/setup.py
@@ -28,10 +28,10 @@ setup(
     keywords='audio music learning',
     license='ISC',
     install_requires=['six',
-                      'librosa>=0.5.0',
-                      'jams>=0.2.3',
+                      'librosa>=0.6.2',
+                      'jams>=0.3',
                       'scikit-learn>=0.20',
-                      'mir_eval>=0.4'],
+                      'mir_eval>=0.5'],
     extras_require={
         'docs': ['numpydoc'],
         'tests': ['pytest', 'pytest-cov', 'keras', 'tensorflow'],

--- a/tests/test_decode.py
+++ b/tests/test_decode.py
@@ -140,7 +140,7 @@ def test_decode_tags_dynamic_soft(sr, hop_length, ann_tag):
     data = tc.transform_annotation(ann_tag, ann_tag.duration)
 
     # Soften the data, but preserve the decisions
-    tags_predict = data['tags'] * 0.51 + 0.1
+    tags_predict = 0.9 * data['tags'] + 0.1 * np.ones_like(data['tags']) / data['tags'].shape[1]
     inverse = tc.inverse(tags_predict, duration=ann_tag.duration)
     for obs in inverse:
         assert 0. <= obs.confidence <= 1.
@@ -167,7 +167,7 @@ def test_decode_tags_static_soft(ann_tag):
     tc = pumpp.task.StaticLabelTransformer('genre', 'tag_gtzan')
 
     data = tc.transform_annotation(ann_tag, ann_tag.duration)
-    tags_predict = data['tags'] * 0.51 + 0.1
+    tags_predict = 0.9 * data['tags'] + 0.1 * np.ones_like(data['tags']) / data['tags'].shape[1]
 
     inverse = tc.inverse(tags_predict, ann_tag.duration)
     for obs in inverse:
@@ -421,14 +421,4 @@ def test_decode_beatpos(sr, hop_length, ann_beat):
     data2 = tc.transform_annotation(inverse, ann_beat.duration)
 
     assert np.allclose(data['position'], data2['position'])
-
-
-# TODO
-#   add some base tests for viterbi decoding in the following cases
-#   events
-#
-#   intervals
-#       +- multi
-#           w/wo independent transitions / inits / states
-#       +- sparse
 

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -334,6 +334,24 @@ def test_task_dlabel_auto(SR, HOP_LENGTH):
         assert type_match(output[key].dtype, trans.fields[key].dtype)
 
 
+@pytest.mark.xfail(raises=pumpp.ParameterError)
+def test_task_dlabel_badself():
+    pumpp.task.DynamicLabelTransformer(name='genre', namespace='tag_gtzan',
+                                       p_self=np.ones(5))
+
+
+@pytest.mark.xfail(raises=pumpp.ParameterError)
+def test_task_dlabel_badinit():
+    pumpp.task.DynamicLabelTransformer(name='genre', namespace='tag_gtzan',
+                                       p_init=np.ones(5))
+
+
+@pytest.mark.xfail(raises=pumpp.ParameterError)
+def test_task_dlabel_badstate():
+    pumpp.task.DynamicLabelTransformer(name='genre', namespace='tag_gtzan',
+                                       p_state=np.ones(5))
+
+
 def test_task_slabel_absent():
     labels = ['alpha', 'beta', 'psycho', 'aqua', 'disco']
 
@@ -848,12 +866,12 @@ def test_task_chord_tag_present(SR, HOP_LENGTH, VOCAB, SPARSE):
 
 @pytest.mark.xfail(raises=pumpp.ParameterError)
 def test_task_chord_tag_badinit():
-    trans = pumpp.task.ChordTagTransformer(name='chord', vocab='3567s', p_init=np.ones(5))
+    pumpp.task.ChordTagTransformer(name='chord', vocab='3567s', p_init=np.ones(5))
 
 
 @pytest.mark.xfail(raises=pumpp.ParameterError)
 def test_task_chord_tag_badstate():
-    trans = pumpp.task.ChordTagTransformer(name='chord', vocab='3567s', p_state=np.ones(5))
+    pumpp.task.ChordTagTransformer(name='chord', vocab='3567s', p_state=np.ones(5))
 
 
 def test_task_chord_tag_absent(SR, HOP_LENGTH, VOCAB, SPARSE):

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -806,7 +806,7 @@ def test_task_chord_tag_present(SR, HOP_LENGTH, VOCAB, SPARSE):
         Y_true_out[11] = 'X'       # sus2 -> X
         Y_true_out[12] = 'X'       # sus4 -> X
     if '6' not in VOCAB:
-        Y_true_out[1] = 'C:min'    # min6 -> maj
+        Y_true_out[1] = 'C:min'    # min6 -> min
         Y_true_out[2] = 'C:maj'    # maj6 -> maj
     if '7' not in VOCAB:
         Y_true_out[5] = 'C#:dim'   # dim7 -> dim
@@ -844,6 +844,16 @@ def test_task_chord_tag_present(SR, HOP_LENGTH, VOCAB, SPARSE):
     Y_expected = np.repeat(Y_true_out, (SR // HOP_LENGTH), axis=0)
 
     assert np.all(Y_pred == Y_expected)
+
+
+@pytest.mark.xfail(raises=pumpp.ParameterError)
+def test_task_chord_tag_badinit():
+    trans = pumpp.task.ChordTagTransformer(name='chord', vocab='3567s', p_init=np.ones(5))
+
+
+@pytest.mark.xfail(raises=pumpp.ParameterError)
+def test_task_chord_tag_badstate():
+    trans = pumpp.task.ChordTagTransformer(name='chord', vocab='3567s', p_state=np.ones(5))
 
 
 def test_task_chord_tag_absent(SR, HOP_LENGTH, VOCAB, SPARSE):
@@ -958,6 +968,7 @@ def test_task_beatpos_present(SR, HOP_LENGTH, MAX_DIVISIONS, SPARSE):
                            axis=0).astype(Y_pred.dtype)
     for i, (y1, y2) in enumerate(zip(Y_pred, Y_expected)):
         assert y1 == y2
+
 
 def test_task_beatpos_tail(SR, HOP_LENGTH, SPARSE):
     # This test checks for implicit end-of-bar encodings

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -616,6 +616,26 @@ def test_task_beat_absent(SR, HOP_LENGTH):
         assert type_match(output[key].dtype, trans.fields[key].dtype)
 
 
+@pytest.mark.xfail(raises=pumpp.ParameterError)
+def test_task_beat_badbeatinit():
+    pumpp.task.BeatTransformer(p_init_beat=np.ones(3))
+
+
+@pytest.mark.xfail(raises=pumpp.ParameterError)
+def test_task_beat_baddowninit():
+    pumpp.task.BeatTransformer(p_init_down=np.ones(3))
+
+
+@pytest.mark.xfail(raises=pumpp.ParameterError)
+def test_task_beat_badbeatstate():
+    pumpp.task.BeatTransformer(p_state_beat=np.ones(3))
+
+
+@pytest.mark.xfail(raises=pumpp.ParameterError)
+def test_task_beat_baddownstate():
+    pumpp.task.BeatTransformer(p_state_down=np.ones(3))
+
+
 def test_task_structure_fields():
 
     trans = pumpp.task.StructureTransformer(name='struct')

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -49,7 +49,7 @@ def shape_match(sh1, sh2):
 
 def type_match(x, y):
 
-    return np.issubdtype(x, y) and np.issubdtype(y, x)
+    return np.issubdtype(np.dtype(x), np.dtype(y)) and np.issubdtype(np.dtype(y), np.dtype(x))
 
 
 def test_task_chord_fields(SPARSE):
@@ -65,9 +65,9 @@ def test_task_chord_fields(SPARSE):
 
     if SPARSE:
         assert trans.fields['mychord/root'].shape == (None, 1)
-        assert np.issubdtype(trans.fields['mychord/root'].dtype, np.int)
+        assert np.issubdtype(trans.fields['mychord/root'].dtype, np.integer)
         assert trans.fields['mychord/bass'].shape == (None, 1)
-        assert np.issubdtype(trans.fields['mychord/bass'].dtype, np.int)
+        assert np.issubdtype(trans.fields['mychord/bass'].dtype, np.integer)
     else:
         assert trans.fields['mychord/root'].shape == (None, 13)
         assert trans.fields['mychord/root'].dtype is np.bool
@@ -761,7 +761,7 @@ def test_task_chord_tag_fields(vocab, vocab_size, SPARSE):
 
     if SPARSE:
         assert trans.fields['mychord/chord'].shape == (None, 1)
-        assert np.issubdtype(trans.fields['mychord/chord'].dtype, np.int)
+        assert np.issubdtype(trans.fields['mychord/chord'].dtype, np.integer)
     else:
         assert trans.fields['mychord/chord'].shape == (None, vocab_size)
         assert trans.fields['mychord/chord'].dtype is np.bool
@@ -886,7 +886,7 @@ def test_task_beatpos_fields(max_divisions, n_states, SPARSE):
 
     if SPARSE:
         assert trans.fields['mybeat/position'].shape == (None, 1)
-        assert np.issubdtype(trans.fields['mybeat/position'].dtype, np.int)
+        assert np.issubdtype(trans.fields['mybeat/position'].dtype, np.integer)
     else:
         assert trans.fields['mybeat/position'].shape == (None, n_states)
         assert trans.fields['mybeat/position'].dtype is np.bool


### PR DESCRIPTION
#### Reference Issue
This PR implements #98, allowing viterbi decoding within task inverse/predictions.


#### What does this implement/fix? Explain your changes.

The `BaseTaskTransformer` class now supports optional viterbi parameters for event and interval decoding.  Since the `decode_*` methods support both multi-class and multi-label formulations, the semantics of viterbi decoding can be either `binary` or `discriminative`, as dictated by the `multi=` parameter.

The derived classes for specific tasks each must provide an API for specifying the viterbi parameters: transition matrix, initial state distribution, and prior/stationary state distribution.  Again, the API for these depends on the semantics of the given task (multi-class or multi-label).

- [x] base decoding implementation
- [x] chord tag decoding (multi=False)
- [x] beat and downbeat decoding (multi=True)
- [x] dynamic tag decoding (multi=True)