### PR TITLE
quantization and explicit dtype

### DIFF
--- a/pumpp/base.py
+++ b/pumpp/base.py
@@ -75,8 +75,8 @@ class Scope:
         ParameterError
             If dtype or shape are improperly specified
         '''
-        if not isinstance(dtype, type):
-            raise ParameterError('dtype={} must be a type'.format(dtype))
+        if not isinstance(dtype, (type, np.dtype)):
+            raise ParameterError('dtype={} must be a type or np.dtype'.format(dtype))
 
         if not (isinstance(shape, Iterable) and
                 all([s is None or isinstance(s, int) for s in shape])):

--- a/pumpp/core.py
+++ b/pumpp/core.py
@@ -246,7 +246,7 @@ class Pump(Slicer):
             for fkey, field in self.opmap[key].fields.items():
                 rstr += '\n  <li>{:s} [shape={}, dtype={}]</li>'.format(fkey,
                                                                         field.shape,
-                                                                        field.dtype.__name__)
+                                                                        repr(field.dtype))
             rstr += '</ul></dd>'
         rstr += '</dl>'
         return rstr

--- a/pumpp/feature/_utils.py
+++ b/pumpp/feature/_utils.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+'''Utilities for feature extraction classes'''
+
+import numpy as np
+
+from ..exceptions import ParameterError
+
+
+def phase_diff(phase, conv):
+    '''Compute the phase differential along a given axis
+
+    Parameters
+    ----------
+    phase : np.ndarray
+        Input phase (in radians)
+
+    conv: {None, 'tf', 'th', 'channels_last', 'channels_first'}
+        Convolution mode
+
+    Returns
+    -------
+    dphase : np.ndarray like `phase`
+        The phase differential.
+    '''
+
+    if conv is None:
+        axis = 0
+    elif conv in ('channels_last', 'tf'):
+        axis = 0
+    elif conv in ('channels_first', 'th'):
+        axis = 1
+
+    # Compute the phase differential
+    dphase = np.empty(phase.shape, dtype=phase.dtype)
+    zero_idx = [slice(None)] * phase.ndim
+    zero_idx[axis] = slice(1)
+    else_idx = [slice(None)] * phase.ndim
+    else_idx[axis] = slice(1, None)
+    zero_idx = tuple(zero_idx)
+    else_idx = tuple(else_idx)
+    dphase[zero_idx] = phase[zero_idx]
+    dphase[else_idx] = np.diff(np.unwrap(phase, axis=axis), axis=axis)
+    return dphase
+
+
+def quantize(x, ref_min=None, ref_max=None, dtype='uint8'):
+    '''Quantize array entries to a fixed dtype.
+
+    Parameters
+    ----------
+    x : np.ndarray
+        The data to quantize
+
+    ref_min : None or float
+
+    ref_max : None or float
+        The reference minimum (maximum) value for quantization.
+        By default, `x.min()` (`x.max()`)
+
+    dtype : np.dtype {'uint8', 'uint16'}
+        The target data type.  Any unsigned int type is supported,
+        but most cases will call for `uint8`.
+
+    Returns
+    -------
+    y : np.ndarray, dtype=dtype
+        The values of `x` quantized to integer values
+    '''
+
+    if ref_min is None:
+        ref_min = np.min(x)
+
+    if ref_max is None:
+        ref_max = np.max(x)
+
+    try:
+        info = np.iinfo(dtype)
+    except ValueError as exc:
+        raise ParameterError('dtype={} must be an unsigned integer type'.format(dtype)) from exc
+    if info.kind != 'u':
+        raise ParameterError('dtype={} must be an unsigned integer type'.format(dtype))
+
+    x_quant = np.empty_like(x, dtype=np.dtype(dtype))
+
+    bins = np.linspace(ref_min, ref_max, num=info.max - info.min + 1)
+    x_quant[:] = np.digitize(x, bins, right=True)
+    x_quant[x > ref_max] = info.max
+    x_quant[x < ref_min] = info.min
+    return x_quant

--- a/pumpp/feature/_utils.py
+++ b/pumpp/feature/_utils.py
@@ -88,3 +88,32 @@ def quantize(x, ref_min=None, ref_max=None, dtype='uint8'):
     x_quant[x > ref_max] = info.max
     x_quant[x < ref_min] = info.min
     return x_quant
+
+
+def to_dtype(x, dtype):
+    '''Convert an array to a target dtype.  Quantize if integrable.
+
+    Parameters
+    ----------
+    x : np.ndarray
+        The input data
+
+    dtype : np.dtype or type specification
+        The target dtype
+
+    Returns
+    -------
+    x_dtype : np.ndarray, dtype=dtype
+        The converted data.
+
+        If dtype is integrable, `x_dtype` will be quantized.
+
+    See Also
+    --------
+    quantize
+    '''
+
+    if np.issubdtype(dtype, np.integer):
+        return quantize(x, dtype=dtype)
+    else:
+        return x.astype(dtype)

--- a/pumpp/feature/base.py
+++ b/pumpp/feature/base.py
@@ -31,8 +31,14 @@ class FeatureExtractor(Scope):
             - 'channels_first' for theano-style 2D convolution
             - 'th' equivalent to 'channels_first'
             - None for 1D or non-convolutional representations
+
+    dtype : str or np.dtype
+        The data type for features produced by this object.  Default is`float32`.
+
+        Setting to `uint8` will produced quantized features.
+
     '''
-    def __init__(self, name, sr, hop_length, conv=None):
+    def __init__(self, name, sr, hop_length, conv=None, dtype='float32'):
 
         super(FeatureExtractor, self).__init__(name)
 
@@ -44,6 +50,7 @@ class FeatureExtractor(Scope):
         self.sr = sr
         self.hop_length = hop_length
         self.conv = conv
+        self.dtype = np.dtype(dtype)
 
     def register(self, key, dimension, dtype, channels=1):
 

--- a/pumpp/feature/base.py
+++ b/pumpp/feature/base.py
@@ -96,39 +96,6 @@ class FeatureExtractor(Scope):
     def transform_audio(self, y):
         raise NotImplementedError
 
-    def phase_diff(self, phase):
-        '''Compute the phase differential along a given axis
-
-        Parameters
-        ----------
-        phase : np.ndarray
-            Input phase (in radians)
-
-        Returns
-        -------
-        dphase : np.ndarray like `phase`
-            The phase differential.
-        '''
-
-        if self.conv is None:
-            axis = 0
-        elif self.conv in ('channels_last', 'tf'):
-            axis = 0
-        elif self.conv in ('channels_first', 'th'):
-            axis = 1
-
-        # Compute the phase differential
-        dphase = np.empty(phase.shape, dtype=phase.dtype)
-        zero_idx = [slice(None)] * phase.ndim
-        zero_idx[axis] = slice(1)
-        else_idx = [slice(None)] * phase.ndim
-        else_idx[axis] = slice(1, None)
-        zero_idx = tuple(zero_idx)
-        else_idx = tuple(else_idx)
-        dphase[zero_idx] = phase[zero_idx]
-        dphase[else_idx] = np.diff(np.unwrap(phase, axis=axis), axis=axis)
-        return dphase
-
     def layers(self):
         '''Construct Keras input layers for the given transformer
 

--- a/pumpp/feature/cqt.py
+++ b/pumpp/feature/cqt.py
@@ -350,27 +350,6 @@ class HCQTPhaseDiff(HCQT):
                       channels=len(self.harmonics))
 
     def transform_audio(self, y):
-        '''Compute the HCQT with unwrapped phase
-
-        Parameters
-        ----------
-        y : np.ndarray
-            The audio buffer
-
-        Returns
-        -------
-        data : dict
-            data['mag'] : np.ndarray, shape=(n_frames, n_bins)
-                CQT magnitude
-
-            data['dphase'] : np.ndarray, shape=(n_frames, n_bins)
-                Unwrapped phase differential
-        '''
-        data = super(HCQTPhaseDiff, self).transform_audio(y)
-        data['dphase'] = phase_diff(data.pop('phase'), self.conv)
-        return data
-
-    def transform_audio(self, y):
         '''Compute the HCQT
 
         Parameters

--- a/pumpp/feature/cqt.py
+++ b/pumpp/feature/cqt.py
@@ -6,6 +6,7 @@ from librosa import cqt, magphase, note_to_hz
 from librosa import amplitude_to_db, get_duration
 from librosa.util import fix_length
 
+from ._utils import phase_diff
 from .base import FeatureExtractor
 from ..exceptions import ParameterError
 
@@ -156,7 +157,7 @@ class CQTPhaseDiff(CQT):
                 Unwrapped phase differential
         '''
         data = super(CQTPhaseDiff, self).transform_audio(y)
-        data['dphase'] = self.phase_diff(data.pop('phase'))
+        data['dphase'] = phase_diff(data.pop('phase'), self.conv)
         return data
 
 
@@ -347,5 +348,5 @@ class HCQTPhaseDiff(HCQT):
                 Unwrapped phase differential
         '''
         data = super(HCQTPhaseDiff, self).transform_audio(y)
-        data['dphase'] = self.phase_diff(data.pop('phase'))
+        data['dphase'] = phase_diff(data.pop('phase'), self.conv)
         return data

--- a/pumpp/feature/fft.py
+++ b/pumpp/feature/fft.py
@@ -35,6 +35,9 @@ class STFT(FeatureExtractor):
 
         Otherwise use linear magnitude.
 
+    conv : str
+        Convolution mode
+
     dtype : np.dtype
         The data type for the output features.  Default is `float32`.
 
@@ -46,14 +49,13 @@ class STFT(FeatureExtractor):
     STFTPhaseDiff
     '''
     def __init__(self, name, sr, hop_length, n_fft, log=False, conv=None, dtype='float32'):
-        super(STFT, self).__init__(name, sr, hop_length, conv=conv)
+        super(STFT, self).__init__(name, sr, hop_length, conv=conv, dtype=dtype)
 
         self.n_fft = n_fft
         self.log = log
-        self.dtype = dtype
 
-        self.register('mag', 1 + n_fft // 2, np.dtype(dtype))
-        self.register('phase', 1 + n_fft // 2, np.dtype(dtype))
+        self.register('mag', 1 + n_fft // 2, self.dtype)
+        self.register('phase', 1 + n_fft // 2, self.dtype)
 
     def transform_audio(self, y):
         '''Compute the STFT magnitude and phase.

--- a/pumpp/feature/fft.py
+++ b/pumpp/feature/fft.py
@@ -7,6 +7,7 @@ from librosa import amplitude_to_db, get_duration
 from librosa.util import fix_length
 
 from .base import FeatureExtractor
+from ._utils import phase_diff
 
 __all__ = ['STFT', 'STFTMag', 'STFTPhaseDiff']
 
@@ -110,7 +111,7 @@ class STFTPhaseDiff(STFT):
                 The unwrapped phase differential
         '''
         data = super(STFTPhaseDiff, self).transform_audio(y)
-        data['dphase'] = self.phase_diff(data.pop('phase'))
+        data['dphase'] = phase_diff(data.pop('phase'), self.conv)
         return data
 
 

--- a/pumpp/feature/mel.py
+++ b/pumpp/feature/mel.py
@@ -41,18 +41,22 @@ class Mel(FeatureExtractor):
         If `True`, scale magnitude in decibels.
 
         Otherwise, use a linear amplitude scale.
+
+    dtype : np.dtype
+        The data type for the output features.  Default is `float32`.
+
+        Setting to `uint8` will produce quantized features.
     '''
     def __init__(self, name, sr, hop_length, n_fft, n_mels, fmax=None,
                  log=False, conv=None, dtype='float32'):
-        super(Mel, self).__init__(name, sr, hop_length, conv=conv)
+        super(Mel, self).__init__(name, sr, hop_length, conv=conv, dtype=dtype)
 
         self.n_fft = n_fft
         self.n_mels = n_mels
         self.fmax = fmax
         self.log = log
-        self.dtype = dtype
 
-        self.register('mag', n_mels, np.dtype(dtype))
+        self.register('mag', n_mels, self.dtype)
 
     def transform_audio(self, y):
         '''Compute the Mel spectrogram

--- a/pumpp/feature/mel.py
+++ b/pumpp/feature/mel.py
@@ -8,6 +8,8 @@ from librosa.util import fix_length
 
 from .base import FeatureExtractor
 
+from ._utils import to_dtype
+
 __all__ = ['Mel']
 
 
@@ -41,15 +43,16 @@ class Mel(FeatureExtractor):
         Otherwise, use a linear amplitude scale.
     '''
     def __init__(self, name, sr, hop_length, n_fft, n_mels, fmax=None,
-                 log=False, conv=None):
+                 log=False, conv=None, dtype='float32'):
         super(Mel, self).__init__(name, sr, hop_length, conv=conv)
 
         self.n_fft = n_fft
         self.n_mels = n_mels
         self.fmax = fmax
         self.log = log
+        self.dtype = dtype
 
-        self.register('mag', n_mels, np.float32)
+        self.register('mag', n_mels, np.dtype(dtype))
 
     def transform_audio(self, y):
         '''Compute the Mel spectrogram
@@ -71,11 +74,14 @@ class Mel(FeatureExtractor):
                                      n_fft=self.n_fft,
                                      hop_length=self.hop_length,
                                      n_mels=self.n_mels,
-                                     fmax=self.fmax)).astype(np.float32)
+                                     fmax=self.fmax))
 
         mel = fix_length(mel, n_frames)
 
         if self.log:
             mel = amplitude_to_db(mel, ref=np.max)
+
+        # Type convert
+        mel = to_dtype(mel, self.dtype)
 
         return {'mag': mel.T[self.idx]}

--- a/pumpp/feature/time.py
+++ b/pumpp/feature/time.py
@@ -6,6 +6,7 @@ import numpy as np
 from librosa import get_duration
 
 from .base import FeatureExtractor
+from ._utils import to_dtype
 
 __all__ = ['TimePosition']
 
@@ -25,11 +26,12 @@ class TimePosition(FeatureExtractor):
         The hop length of analysis windows
     '''
 
-    def __init__(self, name, sr, hop_length, conv=None):
-        super(TimePosition, self).__init__(name, sr, hop_length, conv=conv)
+    def __init__(self, name, sr, hop_length, conv=None, dtype='float32'):
+        super(TimePosition, self).__init__(name, sr, hop_length, conv=conv,
+                                           dtype=dtype)
 
-        self.register('relative', 2, np.float32)
-        self.register('absolute', 2, np.float32)
+        self.register('relative', 2, self.dtype)
+        self.register('absolute', 2, self.dtype)
 
     def transform_audio(self, y):
         '''Compute the time position encoding
@@ -57,5 +59,5 @@ class TimePosition(FeatureExtractor):
 
         absolute = relative * np.sqrt(duration)
 
-        return {'relative': relative[self.idx],
-                'absolute': absolute[self.idx]}
+        return {'relative': to_dtype(relative[self.idx], self.dtype),
+                'absolute': to_dtype(absolute[self.idx], self.dtype)}

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 max-line-length=119
 
 [tool:pytest]
-addopts = -v --cov-report term-missing --cov pumpp
+addopts = --cov-report term-missing --cov pumpp
 filterwarnings =
     ignore:Using a non-tuple sequence:FutureWarning:scipy.*
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -30,7 +30,7 @@ def jam(request):
 
 @pytest.mark.parametrize('audio_f', [None, 'tests/data/test.ogg'])
 @pytest.mark.parametrize('y', [None, 'tests/data/test.ogg'])
-@pytest.mark.parametrize('sr2', [None, 22050, 44100])
+@pytest.mark.parametrize('sr2', [None, 22050])
 @pytest.mark.parametrize('crop', [False, True])
 def test_pump(audio_f, jam, y, sr, sr2, hop_length, crop):
 

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -368,7 +368,7 @@ def test_feature_tempogram_fields(SR, HOP_LENGTH, WIN_LENGTH, conv, dtype):
     assert ext.fields['rhythm/tempogram'].dtype is np.dtype(dtype)
 
 
-def test_feature_tempogram(audio, SR, HOP_LENGTH, WIN_LENGTH, conv):
+def test_feature_tempogram(audio, SR, HOP_LENGTH, WIN_LENGTH, conv, dtype):
 
     ext = pumpp.feature.Tempogram(name='rhythm',
                                   sr=SR, hop_length=HOP_LENGTH,

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -157,6 +157,7 @@ def test_feature_stft(audio, SR, HOP_LENGTH, n_fft, conv, log, dtype):
                              sr=SR, hop_length=HOP_LENGTH,
                              n_fft=n_fft,
                              conv=conv,
+                             log=log,
                              dtype=dtype)
 
     output = ext.transform(**audio)
@@ -174,6 +175,7 @@ def test_feature_stft_phasediff(audio, SR, HOP_LENGTH, n_fft, conv, log, dtype):
                                       sr=SR, hop_length=HOP_LENGTH,
                                       n_fft=n_fft,
                                       conv=conv,
+                                      log=log,
                                       dtype=dtype)
 
     output = ext.transform(**audio)
@@ -192,6 +194,7 @@ def test_feature_stft_mag(audio, SR, HOP_LENGTH, n_fft, conv, log, dtype):
                                 sr=SR, hop_length=HOP_LENGTH,
                                 n_fft=n_fft,
                                 conv=conv,
+                                log=log,
                                 dtype=dtype)
 
     output = ext.transform(**audio)
@@ -226,6 +229,7 @@ def test_feature_mel(audio, SR, HOP_LENGTH, n_fft, n_mels, conv, log, dtype):
                             sr=SR, hop_length=HOP_LENGTH,
                             n_fft=n_fft, n_mels=n_mels,
                             conv=conv,
+                            log=log,
                             dtype=dtype)
 
     output = ext.transform(**audio)

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -79,10 +79,15 @@ def hconv(request):
     return request.param
 
 
-@pytest.fixture(params=[None, [1], [1, 2], [1, 2, 3],
+@pytest.fixture(params=[None, [1], [1, 2],
                         pytest.param([-1], marks=xfail(raises=pumpp.ParameterError)),
                         pytest.param('bad harmonics', marks=xfail(raises=pumpp.ParameterError))])
 def harmonics(request):
+    return request.param
+
+
+@pytest.fixture(params=['uint8', 'float16', np.float32])
+def dtype(request):
     return request.param
 
 
@@ -97,58 +102,62 @@ def __check_shape(fields, key, dim, conv, channels=1):
         assert fields[key].shape == (channels, None, dim)
 
 
-def test_feature_stft_fields(SR, HOP_LENGTH, n_fft, conv, log):
+def test_feature_stft_fields(SR, HOP_LENGTH, n_fft, conv, log, dtype):
 
     ext = pumpp.feature.STFT(name='stft',
                              sr=SR, hop_length=HOP_LENGTH,
                              n_fft=n_fft,
-                             conv=conv)
+                             conv=conv,
+                             dtype=dtype)
 
     # Check the fields
     assert set(ext.fields.keys()) == set(['stft/mag', 'stft/phase'])
 
     __check_shape(ext.fields, 'stft/mag', 1 + n_fft // 2, conv)
     __check_shape(ext.fields, 'stft/phase', 1 + n_fft // 2, conv)
-    assert ext.fields['stft/mag'].dtype is np.float32
-    assert ext.fields['stft/phase'].dtype is np.float32
+    assert ext.fields['stft/mag'].dtype is np.dtype(dtype)
+    assert ext.fields['stft/phase'].dtype is np.dtype(dtype)
 
 
-def test_feature_stft_mag_fields(SR, HOP_LENGTH, n_fft, conv):
+def test_feature_stft_mag_fields(SR, HOP_LENGTH, n_fft, conv, dtype):
 
     ext = pumpp.feature.STFTMag(name='stft',
                                 sr=SR, hop_length=HOP_LENGTH,
                                 n_fft=n_fft,
-                                conv=conv)
+                                conv=conv,
+                                dtype=dtype)
 
     # Check the fields
     assert set(ext.fields.keys()) == set(['stft/mag'])
 
     __check_shape(ext.fields, 'stft/mag', 1 + n_fft // 2, conv)
-    assert ext.fields['stft/mag'].dtype is np.float32
+    assert ext.fields['stft/mag'].dtype is np.dtype(dtype)
 
 
-def test_feature_stft_phasediff_fields(SR, HOP_LENGTH, n_fft, conv):
+def test_feature_stft_phasediff_fields(SR, HOP_LENGTH, n_fft, conv, dtype):
 
     ext = pumpp.feature.STFTPhaseDiff(name='stft',
                                       sr=SR, hop_length=HOP_LENGTH,
                                       n_fft=n_fft,
-                                      conv=conv)
+                                      conv=conv,
+                                      dtype=dtype)
 
     # Check the fields
     assert set(ext.fields.keys()) == set(['stft/mag', 'stft/dphase'])
 
     __check_shape(ext.fields, 'stft/mag', 1 + n_fft // 2, conv)
     __check_shape(ext.fields, 'stft/dphase', 1 + n_fft // 2, conv)
-    assert ext.fields['stft/mag'].dtype is np.float32
-    assert ext.fields['stft/dphase'].dtype is np.float32
+    assert ext.fields['stft/mag'].dtype is np.dtype(dtype)
+    assert ext.fields['stft/dphase'].dtype is np.dtype(dtype)
 
 
-def test_feature_stft(audio, SR, HOP_LENGTH, n_fft, conv, log):
+def test_feature_stft(audio, SR, HOP_LENGTH, n_fft, conv, log, dtype):
 
     ext = pumpp.feature.STFT(name='stft',
                              sr=SR, hop_length=HOP_LENGTH,
                              n_fft=n_fft,
-                             conv=conv)
+                             conv=conv,
+                             dtype=dtype)
 
     output = ext.transform(**audio)
 
@@ -159,12 +168,13 @@ def test_feature_stft(audio, SR, HOP_LENGTH, n_fft, conv, log):
         assert type_match(output[key].dtype, ext.fields[key].dtype)
 
 
-def test_feature_stft_phasediff(audio, SR, HOP_LENGTH, n_fft, conv, log):
+def test_feature_stft_phasediff(audio, SR, HOP_LENGTH, n_fft, conv, log, dtype):
 
     ext = pumpp.feature.STFTPhaseDiff(name='stft',
                                       sr=SR, hop_length=HOP_LENGTH,
                                       n_fft=n_fft,
-                                      conv=conv)
+                                      conv=conv,
+                                      dtype=dtype)
 
     output = ext.transform(**audio)
 
@@ -176,12 +186,13 @@ def test_feature_stft_phasediff(audio, SR, HOP_LENGTH, n_fft, conv, log):
         assert type_match(output[key].dtype, ext.fields[key].dtype)
 
 
-def test_feature_stft_mag(audio, SR, HOP_LENGTH, n_fft, conv, log):
+def test_feature_stft_mag(audio, SR, HOP_LENGTH, n_fft, conv, log, dtype):
 
     ext = pumpp.feature.STFTMag(name='stft',
                                 sr=SR, hop_length=HOP_LENGTH,
                                 n_fft=n_fft,
-                                conv=conv)
+                                conv=conv,
+                                dtype=dtype)
 
     output = ext.transform(**audio)
 
@@ -194,26 +205,28 @@ def test_feature_stft_mag(audio, SR, HOP_LENGTH, n_fft, conv, log):
 
 
 # Mel features
-def test_feature_mel_fields(SR, HOP_LENGTH, n_fft, n_mels, conv):
+def test_feature_mel_fields(SR, HOP_LENGTH, n_fft, n_mels, conv, dtype):
 
     ext = pumpp.feature.Mel(name='mel',
                             sr=SR, hop_length=HOP_LENGTH,
                             n_fft=n_fft, n_mels=n_mels,
-                            conv=conv)
+                            conv=conv,
+                            dtype=dtype)
 
     # Check the fields
     assert set(ext.fields.keys()) == set(['mel/mag'])
 
     __check_shape(ext.fields, 'mel/mag', n_mels, conv)
-    assert ext.fields['mel/mag'].dtype is np.float32
+    assert ext.fields['mel/mag'].dtype is np.dtype(dtype)
 
 
-def test_feature_mel(audio, SR, HOP_LENGTH, n_fft, n_mels, conv, log):
+def test_feature_mel(audio, SR, HOP_LENGTH, n_fft, n_mels, conv, log, dtype):
 
     ext = pumpp.feature.Mel(name='mel',
                             sr=SR, hop_length=HOP_LENGTH,
                             n_fft=n_fft, n_mels=n_mels,
-                            conv=conv)
+                            conv=conv,
+                            dtype=dtype)
 
     output = ext.transform(**audio)
 
@@ -227,64 +240,68 @@ def test_feature_mel(audio, SR, HOP_LENGTH, n_fft, n_mels, conv, log):
 
 # CQT features
 
-def test_feature_cqt_fields(SR, HOP_LENGTH, over_sample, n_octaves, conv):
+def test_feature_cqt_fields(SR, HOP_LENGTH, over_sample, n_octaves, conv, dtype):
 
     ext = pumpp.feature.CQT(name='cqt',
                             sr=SR, hop_length=HOP_LENGTH,
                             n_octaves=n_octaves,
                             over_sample=over_sample,
-                            conv=conv)
+                            conv=conv,
+                            dtype=dtype)
 
     # Check the fields
     assert set(ext.fields.keys()) == set(['cqt/mag', 'cqt/phase'])
 
     __check_shape(ext.fields, 'cqt/mag', over_sample * n_octaves * 12, conv)
     __check_shape(ext.fields, 'cqt/phase', over_sample * n_octaves * 12, conv)
-    assert ext.fields['cqt/mag'].dtype is np.float32
-    assert ext.fields['cqt/phase'].dtype is np.float32
+    assert ext.fields['cqt/mag'].dtype is np.dtype(dtype)
+    assert ext.fields['cqt/phase'].dtype is np.dtype(dtype)
 
 
-def test_feature_cqtmag_fields(SR, HOP_LENGTH, over_sample, n_octaves, conv):
+def test_feature_cqtmag_fields(SR, HOP_LENGTH, over_sample, n_octaves, conv, dtype):
 
     ext = pumpp.feature.CQTMag(name='cqt',
                                sr=SR, hop_length=HOP_LENGTH,
                                n_octaves=n_octaves,
                                over_sample=over_sample,
-                               conv=conv)
+                               conv=conv,
+                               dtype=dtype)
 
     # Check the fields
     assert set(ext.fields.keys()) == set(['cqt/mag'])
 
     __check_shape(ext.fields, 'cqt/mag', over_sample * n_octaves * 12, conv)
-    assert ext.fields['cqt/mag'].dtype is np.float32
+    assert ext.fields['cqt/mag'].dtype is np.dtype(dtype)
 
 
 def test_feature_cqtphasediff_fields(SR, HOP_LENGTH, over_sample, n_octaves,
-                                     conv):
+                                     conv, dtype):
 
     ext = pumpp.feature.CQTPhaseDiff(name='cqt',
                                      sr=SR, hop_length=HOP_LENGTH,
                                      n_octaves=n_octaves,
                                      over_sample=over_sample,
-                                     conv=conv)
+                                     conv=conv,
+                                     dtype=dtype)
 
     # Check the fields
     assert set(ext.fields.keys()) == set(['cqt/mag', 'cqt/dphase'])
 
     __check_shape(ext.fields, 'cqt/mag', over_sample * n_octaves * 12, conv)
     __check_shape(ext.fields, 'cqt/dphase', over_sample * n_octaves * 12, conv)
-    assert ext.fields['cqt/mag'].dtype is np.float32
-    assert ext.fields['cqt/dphase'].dtype is np.float32
+    assert ext.fields['cqt/mag'].dtype is np.dtype(dtype)
+    assert ext.fields['cqt/dphase'].dtype is np.dtype(dtype)
 
 
-def test_feature_cqt(audio, SR, HOP_LENGTH, over_sample, n_octaves, conv, log):
+def test_feature_cqt(audio, SR, HOP_LENGTH, over_sample, n_octaves, conv, log, dtype):
 
     ext = pumpp.feature.CQT(name='cqt',
                             sr=SR, hop_length=HOP_LENGTH,
                             n_octaves=n_octaves,
                             over_sample=over_sample,
                             log=log,
-                            conv=conv)
+                            conv=conv,
+                            dtype=dtype)
 
     output = ext.transform(**audio)
 
@@ -296,14 +313,15 @@ def test_feature_cqt(audio, SR, HOP_LENGTH, over_sample, n_octaves, conv, log):
 
 
 def test_feature_cqtmag(audio, SR, HOP_LENGTH, over_sample, n_octaves, conv,
-                        log):
+                        log, dtype):
 
     ext = pumpp.feature.CQTMag(name='cqt',
                                sr=SR, hop_length=HOP_LENGTH,
                                n_octaves=n_octaves,
                                over_sample=over_sample,
                                log=log,
-                               conv=conv)
+                               conv=conv,
+                               dtype=dtype)
 
     output = ext.transform(**audio)
 
@@ -315,14 +333,15 @@ def test_feature_cqtmag(audio, SR, HOP_LENGTH, over_sample, n_octaves, conv,
 
 
 def test_feature_cqtphasediff(audio, SR, HOP_LENGTH, over_sample, n_octaves,
-                              conv, log):
+                              conv, log, dtype):
 
     ext = pumpp.feature.CQTPhaseDiff(name='cqt',
                                      sr=SR, hop_length=HOP_LENGTH,
                                      n_octaves=n_octaves,
                                      over_sample=over_sample,
                                      log=log,
-                                     conv=conv)
+                                     conv=conv,
+                                     dtype=dtype)
 
     output = ext.transform(**audio)
 
@@ -334,18 +353,19 @@ def test_feature_cqtphasediff(audio, SR, HOP_LENGTH, over_sample, n_octaves,
 
 
 # Rhythm features
-def test_feature_tempogram_fields(SR, HOP_LENGTH, WIN_LENGTH, conv):
+def test_feature_tempogram_fields(SR, HOP_LENGTH, WIN_LENGTH, conv, dtype):
 
     ext = pumpp.feature.Tempogram(name='rhythm',
                                   sr=SR, hop_length=HOP_LENGTH,
                                   win_length=WIN_LENGTH,
-                                  conv=conv)
+                                  conv=conv,
+                                  dtype=dtype)
 
     # Check the fields
     assert set(ext.fields.keys()) == set(['rhythm/tempogram'])
 
     __check_shape(ext.fields, 'rhythm/tempogram', WIN_LENGTH, conv)
-    assert ext.fields['rhythm/tempogram'].dtype is np.float32
+    assert ext.fields['rhythm/tempogram'].dtype is np.dtype(dtype)
 
 
 def test_feature_tempogram(audio, SR, HOP_LENGTH, WIN_LENGTH, conv):
@@ -353,7 +373,8 @@ def test_feature_tempogram(audio, SR, HOP_LENGTH, WIN_LENGTH, conv):
     ext = pumpp.feature.Tempogram(name='rhythm',
                                   sr=SR, hop_length=HOP_LENGTH,
                                   win_length=WIN_LENGTH,
-                                  conv=conv)
+                                  conv=conv,
+                                  dtype=dtype)
 
     output = ext.transform(**audio)
 
@@ -364,28 +385,30 @@ def test_feature_tempogram(audio, SR, HOP_LENGTH, WIN_LENGTH, conv):
         assert type_match(output[key].dtype, ext.fields[key].dtype)
 
 
-def test_feature_temposcale_fields(SR, HOP_LENGTH, WIN_LENGTH, N_FMT, conv):
+def test_feature_temposcale_fields(SR, HOP_LENGTH, WIN_LENGTH, N_FMT, conv, dtype):
 
     ext = pumpp.feature.TempoScale(name='rhythm',
                                    sr=SR, hop_length=HOP_LENGTH,
                                    win_length=WIN_LENGTH,
                                    n_fmt=N_FMT,
-                                   conv=conv)
+                                   conv=conv,
+                                   dtype=dtype)
 
     # Check the fields
     assert set(ext.fields.keys()) == set(['rhythm/temposcale'])
 
     __check_shape(ext.fields, 'rhythm/temposcale', 1 + N_FMT // 2, conv)
-    assert ext.fields['rhythm/temposcale'].dtype is np.float32
+    assert ext.fields['rhythm/temposcale'].dtype is np.dtype(dtype)
 
 
-def test_feature_temposcale(audio, SR, HOP_LENGTH, WIN_LENGTH, N_FMT, conv):
+def test_feature_temposcale(audio, SR, HOP_LENGTH, WIN_LENGTH, N_FMT, conv, dtype):
 
     ext = pumpp.feature.TempoScale(name='rhythm',
                                    sr=SR, hop_length=HOP_LENGTH,
                                    win_length=WIN_LENGTH,
                                    n_fmt=N_FMT,
-                                   conv=conv)
+                                   conv=conv,
+                                   dtype=dtype)
 
     output = ext.transform(**audio)
 
@@ -399,14 +422,15 @@ def test_feature_temposcale(audio, SR, HOP_LENGTH, WIN_LENGTH, N_FMT, conv):
 # HCQT features
 
 def test_feature_hcqt_fields(SR, HOP_LENGTH, over_sample, n_octaves,
-                             hconv, harmonics):
+                             hconv, harmonics, dtype):
 
     ext = pumpp.feature.HCQT(name='hcqt',
                              sr=SR, hop_length=HOP_LENGTH,
                              n_octaves=n_octaves,
                              over_sample=over_sample,
                              conv=hconv,
-                             harmonics=harmonics)
+                             harmonics=harmonics,
+                             dtype=dtype)
 
     # Check the fields
     assert set(ext.fields.keys()) == set(['hcqt/mag', 'hcqt/phase'])
@@ -420,18 +444,19 @@ def test_feature_hcqt_fields(SR, HOP_LENGTH, over_sample, n_octaves,
                   hconv, channels=channels)
     __check_shape(ext.fields, 'hcqt/phase', over_sample * n_octaves * 12,
                   hconv, channels=channels)
-    assert ext.fields['hcqt/mag'].dtype is np.float32
-    assert ext.fields['hcqt/phase'].dtype is np.float32
+    assert ext.fields['hcqt/mag'].dtype is np.dtype(dtype)
+    assert ext.fields['hcqt/phase'].dtype is np.dtype(dtype)
 
 
 def test_feature_hcqtmag_fields(SR, HOP_LENGTH, over_sample, n_octaves,
-                                hconv, harmonics):
+                                hconv, harmonics, dtype):
 
     ext = pumpp.feature.HCQTMag(name='hcqt',
                                 sr=SR, hop_length=HOP_LENGTH,
                                 n_octaves=n_octaves,
                                 over_sample=over_sample,
-                                conv=hconv, harmonics=harmonics)
+                                conv=hconv, harmonics=harmonics,
+                                dtype=dtype)
 
     if not harmonics:
         channels = 1
@@ -443,17 +468,18 @@ def test_feature_hcqtmag_fields(SR, HOP_LENGTH, over_sample, n_octaves,
 
     __check_shape(ext.fields, 'hcqt/mag', over_sample * n_octaves * 12,
                   hconv, channels=channels)
-    assert ext.fields['hcqt/mag'].dtype is np.float32
+    assert ext.fields['hcqt/mag'].dtype is np.dtype(dtype)
 
 
 def test_feature_hcqtphasediff_fields(SR, HOP_LENGTH, over_sample, n_octaves,
-                                      hconv, harmonics):
+                                      hconv, harmonics, dtype):
 
     ext = pumpp.feature.HCQTPhaseDiff(name='hcqt',
                                       sr=SR, hop_length=HOP_LENGTH,
                                       n_octaves=n_octaves,
                                       over_sample=over_sample,
-                                      conv=hconv, harmonics=harmonics)
+                                      conv=hconv, harmonics=harmonics,
+                                      dtype=dtype)
 
     if not harmonics:
         channels = 1
@@ -467,12 +493,12 @@ def test_feature_hcqtphasediff_fields(SR, HOP_LENGTH, over_sample, n_octaves,
                   hconv, channels=channels)
     __check_shape(ext.fields, 'hcqt/dphase', over_sample * n_octaves * 12,
                   hconv, channels=channels)
-    assert ext.fields['hcqt/mag'].dtype is np.float32
-    assert ext.fields['hcqt/dphase'].dtype is np.float32
+    assert ext.fields['hcqt/mag'].dtype is np.dtype(dtype)
+    assert ext.fields['hcqt/dphase'].dtype is np.dtype(dtype)
 
 
 def test_feature_hcqt(audio, SR, HOP_LENGTH, over_sample, n_octaves,
-                      hconv, log, harmonics):
+                      hconv, log, harmonics, dtype):
 
     ext = pumpp.feature.HCQT(name='hcqt',
                              sr=SR, hop_length=HOP_LENGTH,
@@ -480,7 +506,8 @@ def test_feature_hcqt(audio, SR, HOP_LENGTH, over_sample, n_octaves,
                              over_sample=over_sample,
                              conv=hconv,
                              log=log,
-                             harmonics=harmonics)
+                             harmonics=harmonics,
+                             dtype=dtype)
 
     output = ext.transform(**audio)
 
@@ -492,7 +519,7 @@ def test_feature_hcqt(audio, SR, HOP_LENGTH, over_sample, n_octaves,
 
 
 def test_feature_hcqtmag(audio, SR, HOP_LENGTH, over_sample, n_octaves,
-                         hconv, log, harmonics):
+                         hconv, log, harmonics, dtype):
 
     ext = pumpp.feature.HCQTMag(name='hcqt',
                                 sr=SR, hop_length=HOP_LENGTH,
@@ -500,7 +527,8 @@ def test_feature_hcqtmag(audio, SR, HOP_LENGTH, over_sample, n_octaves,
                                 over_sample=over_sample,
                                 conv=hconv,
                                 log=log,
-                                harmonics=harmonics)
+                                harmonics=harmonics,
+                                dtype=dtype)
 
     output = ext.transform(**audio)
 
@@ -512,7 +540,7 @@ def test_feature_hcqtmag(audio, SR, HOP_LENGTH, over_sample, n_octaves,
 
 
 def test_feature_hcqtphasediff(audio, SR, HOP_LENGTH, over_sample, n_octaves,
-                               hconv, log, harmonics):
+                               hconv, log, harmonics, dtype):
 
     ext = pumpp.feature.HCQTPhaseDiff(name='hcqt',
                                       sr=SR, hop_length=HOP_LENGTH,
@@ -520,7 +548,8 @@ def test_feature_hcqtphasediff(audio, SR, HOP_LENGTH, over_sample, n_octaves,
                                       over_sample=over_sample,
                                       conv=hconv,
                                       log=log,
-                                      harmonics=harmonics)
+                                      harmonics=harmonics,
+                                      dtype=dtype)
 
     output = ext.transform(**audio)
 
@@ -533,28 +562,30 @@ def test_feature_hcqtphasediff(audio, SR, HOP_LENGTH, over_sample, n_octaves,
 
 # Time Features
 
-def test_feature_time_fields(SR, HOP_LENGTH, conv):
+def test_feature_time_fields(SR, HOP_LENGTH, conv, dtype):
 
     ext = pumpp.feature.TimePosition(name='time',
                                      sr=SR,
                                      hop_length=HOP_LENGTH,
-                                     conv=conv)
+                                     conv=conv,
+                                     dtype=dtype)
 
     assert set(ext.fields.keys()) == set(['time/absolute', 'time/relative'])
 
     __check_shape(ext.fields, 'time/absolute', 2, conv)
     __check_shape(ext.fields, 'time/relative', 2, conv)
 
-    assert ext.fields['time/absolute'].dtype is np.float32
-    assert ext.fields['time/relative'].dtype is np.float32
+    assert ext.fields['time/absolute'].dtype is np.dtype(dtype)
+    assert ext.fields['time/relative'].dtype is np.dtype(dtype)
 
 
-def test_feature_time(audio, SR, HOP_LENGTH, conv):
+def test_feature_time(audio, SR, HOP_LENGTH, conv, dtype):
 
     ext = pumpp.feature.TimePosition(name='time',
                                      sr=SR,
                                      hop_length=HOP_LENGTH,
-                                     conv=conv)
+                                     conv=conv,
+                                     dtype=dtype)
 
     output = ext.transform(**audio)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+'''Tests for feature utility helpers'''
+
+import pytest
+import numpy as np
+
+import pumpp
+import pumpp.feature._utils
+
+
+@pytest.mark.parametrize('dtype', ['uint8', np.uint8])
+def test_quantize(dtype):
+
+    # The range -5 to 5 is broken into 256 equal pieces
+    # -5/3 lands at 85 (1/3)
+    # 5/3 lands at 2*85 = 270
+    # 5 lands at the max
+    x = np.asarray([-5, -5/3, 5/3, 5])
+    y = pumpp.feature._utils.quantize(x, dtype=dtype)
+    assert np.allclose(y, [0, 85, 170, 255])
+
+
+def test_quantize_min():
+    x = np.asarray([-5, -5/3, 5/3, 5])
+    y = pumpp.feature._utils.quantize(x, ref_min=0)
+    assert np.allclose(y, [0, 0, 85, 255])
+
+
+def test_quantize_max():
+    x = np.asarray([-5, -5/3, 5/3, 5])
+    y = pumpp.feature._utils.quantize(x, ref_max=0)
+    assert np.allclose(y, [0, 170, 255, 255])
+
+
+@pytest.mark.xfail(raises=pumpp.ParameterError)
+@pytest.mark.parametrize('dtype', ['int8', 'float32'])
+def test_quantize_bad_dtype(dtype):
+    x = np.asarray([-5, -5/3, 5/3, 5])
+    pumpp.feature._utils.quantize(x, dtype=dtype)


### PR DESCRIPTION
#### Reference Issue

#103 
#104 


#### What does this implement/fix? Explain your changes.

This PR adds quantization of extracted features.  It will also add explicit dtypes, and refactor some of the feature classes to be a bit less interdependent.

Enabling quantization will be automatic if the extractor object is instantiated with `dtype='uint8'` or `dtype='uint16'`.  Otherwise, it will cast to the given float type (`'float32'` by default, but it could be `float16` or `float64` as well.)
