### PR TITLE
generified layers api

### DIFF
--- a/pumpp/core.py
+++ b/pumpp/core.py
@@ -203,9 +203,14 @@ class Pump(Slicer):
 
         return out
 
-    def layers(self):
-        '''Construct Keras input layers for all feature transformers
+    def layers(self, api='keras'):
+        '''Construct input layers for all feature transformers
         in the pump.
+
+        Parameters
+        ----------
+        api : {'keras', ...}
+            Which API to use for layer construction
 
         Returns
         -------
@@ -217,7 +222,7 @@ class Pump(Slicer):
         layermap = dict()
         for operator in self.ops:
             if hasattr(operator, 'layers'):
-                layermap.update(operator.layers())
+                layermap.update(operator.layers(api=api))
         return layermap
 
     def __getitem__(self, key):

--- a/pumpp/feature/base.py
+++ b/pumpp/feature/base.py
@@ -103,8 +103,11 @@ class FeatureExtractor(Scope):
     def transform_audio(self, y):
         raise NotImplementedError
 
-    def layers(self):
-        '''Construct Keras input layers for the given transformer
+    def layers(self, api='keras'):
+        '''Construct input layers for the given transformer
+
+        Parameters
+        ----------
 
         Returns
         -------
@@ -112,6 +115,13 @@ class FeatureExtractor(Scope):
             A dictionary of keras input layers, keyed by the corresponding
             field keys.
         '''
+
+        if api == 'keras':
+            return self.layers_keras()
+        else:
+            raise ParameterError('Unsupported layer api={}'.format(api))
+
+    def layers_keras(self):
         from keras.layers import Input
 
         L = dict()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -187,7 +187,7 @@ def test_pump_sampler(sr, hop_length, n_samples, duration, rng):
     assert S1.duration == S2.duration
 
 
-@pytest.mark.skip
+#@pytest.mark.skip
 def test_pump_layers(sr, hop_length):
     ops = [pumpp.feature.STFT(name='stft', sr=sr,
                               hop_length=hop_length,


### PR DESCRIPTION
#### Reference Issue

#105 

#### What does this implement/fix? Explain your changes.

Adds argument `api=` to `layers()` methods, which dispatches to different deep learning packages for layer construction.

Currently only keras is supported, but this will make it easy to add other frameworks later.

- [ ] tensorflow (tf.placeholder variables)
- [ ] pytorch?
- [ ] ???