### PR TITLE
added query to TaskTransformer.__init__

### DIFF
--- a/pumpp/task/base.py
+++ b/pumpp/task/base.py
@@ -49,7 +49,7 @@ class BaseTaskTransformer(Scope):
         The number of samples between frames
     '''
 
-    def __init__(self, name, namespace, sr, hop_length):
+    def __init__(self, name, namespace, sr, hop_length, query=None):
         super(BaseTaskTransformer, self).__init__(name)
 
         # This will trigger an exception if the namespace is not found
@@ -58,6 +58,7 @@ class BaseTaskTransformer(Scope):
         self.namespace = namespace
         self.sr = sr
         self.hop_length = hop_length
+        self.query = query if query is not None else {}
 
     def empty(self, duration):
         '''Create an empty jams.Annotation for this task.
@@ -93,7 +94,8 @@ class BaseTaskTransformer(Scope):
             will be converted.
         '''
         anns = []
-        if query:
+        if query or self.query:
+            query = dict(self.query, **(query or {}))
             results = jam.search(**query)
         else:
             results = jam.annotations

--- a/pumpp/task/beat.py
+++ b/pumpp/task/beat.py
@@ -51,11 +51,11 @@ class BeatTransformer(BaseTaskTransformer):
     '''
     def __init__(self, name='beat', sr=22050, hop_length=512,
                  p_self_beat=None, p_init_beat=None, p_state_beat=None,
-                 p_self_down=None, p_init_down=None, p_state_down=None):
+                 p_self_down=None, p_init_down=None, p_state_down=None, **kw):
 
         super(BeatTransformer, self).__init__(name=name,
                                               namespace='beat',
-                                              sr=sr, hop_length=hop_length)
+                                              sr=sr, hop_length=hop_length, **kw)
 
         self.set_transition_beat(p_self_beat)
 

--- a/pumpp/task/chord.py
+++ b/pumpp/task/chord.py
@@ -67,12 +67,12 @@ class ChordTransformer(BaseTaskTransformer):
     --------
     SimpleChordTransformer
     '''
-    def __init__(self, name='chord', sr=22050, hop_length=512, sparse=False):
+    def __init__(self, name='chord', sr=22050, hop_length=512, sparse=False, **kw):
         '''Initialize a chord task transformer'''
 
         super(ChordTransformer, self).__init__(name=name,
                                                namespace='chord',
-                                               sr=sr, hop_length=hop_length)
+                                               sr=sr, hop_length=hop_length, **kw)
 
         self.encoder = MultiLabelBinarizer()
         self.encoder.fit([list(range(12))])

--- a/pumpp/task/regression.py
+++ b/pumpp/task/regression.py
@@ -29,10 +29,10 @@ class VectorTransformer(BaseTaskTransformer):
     dtype : np.dtype
         The desired data type of the output
     '''
-    def __init__(self, name, namespace, dimension, dtype=np.float32):
+    def __init__(self, name, namespace, dimension, dtype=np.float32, **kw):
         super(VectorTransformer, self).__init__(name=name,
                                                 namespace=namespace,
-                                                sr=1, hop_length=1)
+                                                sr=1, hop_length=1, **kw)
 
         self.dimension = dimension
         self.dtype = dtype

--- a/pumpp/task/structure.py
+++ b/pumpp/task/structure.py
@@ -29,13 +29,13 @@ class StructureTransformer(BaseTaskTransformer):
         The number of samples between each annotation frame
     '''
 
-    def __init__(self, name='structure', sr=22050, hop_length=512):
+    def __init__(self, name='structure', sr=22050, hop_length=512, **kw):
         '''Initialize a structure agreement transformer'''
 
         super(StructureTransformer, self).__init__(name=name,
                                                    namespace='segment_open',
                                                    sr=sr,
-                                                   hop_length=hop_length)
+                                                   hop_length=hop_length, **kw)
 
         self.register('agree', [None, None], np.bool)
 

--- a/pumpp/task/tags.py
+++ b/pumpp/task/tags.py
@@ -53,11 +53,11 @@ class DynamicLabelTransformer(BaseTaskTransformer):
     StaticLabelTransformer
     '''
     def __init__(self, name, namespace, labels=None, sr=22050, hop_length=512,
-                 p_self=None, p_init=None, p_state=None):
+                 p_self=None, p_init=None, p_state=None, **kw):
         super(DynamicLabelTransformer, self).__init__(name=name,
                                                       namespace=namespace,
                                                       sr=sr,
-                                                      hop_length=hop_length)
+                                                      hop_length=hop_length, **kw)
 
         if labels is None:
             labels = jams.schema.values(namespace)


### PR DESCRIPTION
Seeing as Pump.transform doesn't propagate `query` to `TaskTransformer.transform` and ppl might want to filter annotations the same way for all files, I added a `query` argument to the TaskTransformer constructor. (I also had to propagate kw args across task transformers cuz that wasn't happening)