### PR TITLE
LambdaTransformer (Scaper compatibility)

### DIFF
--- a/pumpp/feature/base.py
+++ b/pumpp/feature/base.py
@@ -118,6 +118,7 @@ class FeatureExtractor(Scope):
 
         if api == 'keras':
             return self.layers_keras()
+
         elif api in ('tf', 'tensorflow'):
             return self.layers_tensorflow()
         else:

--- a/pumpp/task/__init__.py
+++ b/pumpp/task/__init__.py
@@ -25,3 +25,4 @@ from .regression import *
 from .tags import *
 from .structure import *
 from .key import *
+from .lambd import *

--- a/pumpp/task/base.py
+++ b/pumpp/task/base.py
@@ -49,7 +49,7 @@ class BaseTaskTransformer(Scope):
         The number of samples between frames
     '''
 
-    def __init__(self, name, namespace, sr, hop_length):
+    def __init__(self, name, namespace, sr=22050, hop_length=512):
         super(BaseTaskTransformer, self).__init__(name)
 
         # This will trigger an exception if the namespace is not found
@@ -130,13 +130,13 @@ class BaseTaskTransformer(Scope):
 
     def transform_annotation(self, ann, duration):
         '''Transform jams.Annotation to make data for a given task.
-        
+
         Parameters
         ----------
         ann : jams.Annotation
             The jams annotation containing the data
 
-        duration : number > 0 
+        duration : number > 0
            time in seconds of the output duration
 
         Returns

--- a/pumpp/task/lambd.py
+++ b/pumpp/task/lambd.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python
+# -*- enconding: utf-8 -*-
+'''Generic annotation transformation'''
+
+import numpy as np
+import jams
+
+from librosa import time_to_frames
+from librosa.sequence import transition_loop, transition_cycle
+from mir_eval.util import boundaries_to_intervals, adjust_intervals
+
+from .base import BaseTaskTransformer, fill_value
+from ..exceptions import ParameterError
+from .. import util
+
+__all__ = ['LambdaTransformer']
+
+class LambdaTransformer(BaseTaskTransformer):
+    '''General annotation transformer.
+
+    This tries to offer a flexible way of extracting jams observation values.
+
+    Attributes
+    ----------
+    name : str
+        The name of this transformer object
+
+    namespace : str
+        The JAMS namespace for this task
+
+    fields : list of tuples/str - with signature (name, shape, dtype)
+        The list of field definitions to be returned by ``reduce(values)``.
+        These become the arguments to ``self.register``
+
+        If value is of type ``object``, the fields can most likely be inferred
+        from the schema.  If no fields are specified, all fields from the schema
+        will be used.
+        If fields are passed as strings, the dtype will be derived from the schema,
+        and given a shape of (None, 1).
+
+        If value is not of type `object`, a single field `(namespace, (None,1), value_type)`
+        will be assumed.
+
+    query : same format as ``observation.value``, callable [optional]
+        a query compatible with ``match_query``.
+
+        see ``match_query`` for a description.
+
+    reduce : callable [optional]
+        A function that takes the list of the observation values in each interval
+        and returns a dictionary of extracted data keys as expected by Pump.
+        if ``multi`` is False, the function will take a single observation
+        value (useful for value_type == 'object', but possibly trivial otherwise.).
+
+        If ``reduce`` is not specified, an appropriate function will be derived from
+        the ``fields`` parameter and the jams annotation schema.
+
+            If the schema value type is ``'object'``, it will set the output data dict
+            to the values for each field taken from the observation dict.
+            If ``multi`` is True, each field will contain a list of values, otherwise,
+            each key will be the value of that field.
+
+            If the value type is not an object and only one field is defined,
+            the value is returned as {fields[0].name: value}.
+
+    multi : bool [optional]:
+        Whether to support multiple events in a single interval. If ``multi`` is False,
+        it will select the value index according to `LambdaTransformer.SINGLE_INDEX`.
+        If ``multi`` is True, the ``reduce`` function will receive all values in
+        the interval.
+
+    sr : number > 0
+        The audio sampling rate
+
+    hop_length : int > 0
+        The hop length for annotation frames
+
+    Examples
+    --------
+    ```python
+    # all fields
+    LambdaTransformer('scaper', 'scaper')
+    # fields (shape=(None, 1), dtype=inferred): [
+    #    label, source_file, source_time, event_time, event_duration, snr,
+    #    time_stretch, pitch_shift, role],
+
+    # all fields all events
+    LambdaTransformer('scaper', 'scaper', multi=True)
+    # fields (shape=(None, None), dtype=inferred): [
+    #    label, source_file, source_time, event_time, event_duration, snr,
+    #    time_stretch, pitch_shift, role],
+
+    # infer dtype from schema
+    LambdaTransformer('scaper', 'scaper', ['label', 'snr'])
+
+    # equivalent with explicit dtype
+    LambdaTransformer('scaper', 'scaper', [
+        ('label', (None, 1), np.object_),
+        ('snr', (None, 1), np.float),
+    ])
+
+    # snr of only foreground events (takes the last occurring event)
+    LambdaTransformer(
+        'scaper', 'scaper', ['snr'],
+        query={'role': 'foreground'})
+
+    # get encoded labels of all foreground events ()
+    encoder = MultiLabelBinarizer().fit([POSSIBLE_LABELS])
+    LambdaTransformer(
+        'scaper', 'scaper', fields=['label'],
+        query={'role': 'foreground'},
+        multi=True,
+        reduce=lambda values: {
+            # TODO: make sure the shape comes out right
+            'label': np.sum(encoder.transform([[v['label'] for v in values]]), axis=0),
+        },
+    )
+    ```
+
+    '''
+
+    def __init__(self, name, namespace, fields=(), query=None, reduce=None,
+                 multi=False, sample_index=-1, **kw):
+        super().__init__(name, namespace, **kw)
+        self.value_query = query
+        self.multi = multi
+
+        # infer missing fields / dtype for missing reducer
+        fields, value_has_keys = _check_fields(fields, namespace, multi)
+
+        # get default reducer when none is specified
+        if not self.reducer and not reduce:
+            reduce = _default_reducer(fields, value_has_keys, multi)
+
+        # store reducer
+        if reduce:
+            self.reducer = reduce
+
+        # register fields
+        for name, shape, dtype in fields:
+            self.register(name, shape, dtype)
+
+        # fills any missing values from self.reducer
+        self.FILL_DICT = {
+            name: fill_value(dtype) for name, shape, dtype in fields
+        }
+        # select which value in the event of multiple values in interval
+        self.SINGLE_INDEX = sample_index
+
+    # Either override by passing a function like `__init__(reduce=lambda x: ...)`
+    # or by overriding with a subclass.
+    reducer = None
+
+    def transform_annotation(self, annotation, duration):
+        # get observations as lists
+        intervals, values = annotation.to_interval_values()
+
+        # filter values that match query
+        intervals, values = zip(*[
+            (i, d) for i, d in zip(intervals, values)
+            if util.match_query(d, self.value_query)
+        ])
+
+        # get temporal slices, using one hot observation encoding
+        idxs = np.eye(len(intervals))
+        targets = self.encode_intervals(duration, intervals, idxs,
+                                        multi=True, dtype=int, fill=0)
+
+        # get the values in each interval window
+        idxs = (np.where(i)[0] for i in targets)
+
+        if self.multi:
+            target_vals = ([values[j] for j in i] for i in idxs)
+        else:
+            target_vals = (values[i[self.SINGLE_INDEX]]
+                           if len(i) else None for i in idxs)
+
+        # reduce into a data dict for each interval
+        data = [dict(self.FILL_DICT, **self.reducer(e)) for e in target_vals]
+
+        # merge the list of dicts into a dict of lists/arrays
+        return {
+            key: np.array([np.asarray(d[key]) for d in data])
+            # if all(s is not None for s in self.fields[key].shape[1:])
+            # else [d[key] for d in data]
+            for key in set().union(*data)
+        }
+
+    def inverse(self, x, duration=None):
+        raise NotImplementedError('Lambda annotations cannot be inverted')
+
+
+
+############
+# Utilities
+############
+
+
+def __get_type(spec):
+    '''hot fix for https://github.com/marl/jams/issues/205
+
+    Adds support for e.g. `spec['type'] == ['number', 'null']`
+    '''
+    if 'type' in spec:
+        if isinstance(spec['type'], (list, tuple)):
+            # get dtype for each type in list
+            types = [jams.schema.__TYPE_MAP__.get(t, np.object_)
+                     for t in spec['type']]
+
+            # If they're not all equal, return object
+            if all([t == types[0] for t in types]):
+                return types[0]
+            return np.object_
+    return jams.schema.__get_dtype(spec)
+
+
+def _check_fields(fields, namespace, multi):
+    '''
+    Validate the fields passed and try to infer fields from incomplete info.
+
+    see `LambdaTransformer.__init__` for argument descriptions.
+
+    Returns
+    -------
+        fields : list of tuples
+            the fully qualified field spec tuples
+        value_type : np.dtype
+            the dtype of the observation value
+
+    '''
+    schema = jams.schema.namespace(namespace)
+    value_type, _ = jams.schema.get_dtypes(namespace)
+
+    if isinstance(fields, str):
+        fields = [fields]
+    else:
+        fields = list(fields)
+
+    # get object field dtypes
+    try:
+        dtypes = {
+            name: __get_type(spec) for name, spec in
+            schema['properties']['value']['properties'].items()
+        }
+        value_has_keys = schema['properties']['value']['type'] == 'object'
+    except KeyError:
+        value_has_keys = False
+        dtypes = {}
+
+    # get default shape
+    if multi:
+        default_shape = (None, None)
+    else:
+        default_shape = (None, 1)
+
+    if dtypes:
+        # set default fields as all object props
+        if not fields:
+            fields = [(name, default_shape, dtype)
+                      for name, dtype in dtypes.items()]
+
+        # check if any fields were passed as strings and try to infer
+        # them from the schema
+        else:
+            for i, f in enumerate(fields):
+                if isinstance(f, str):
+                    fields[i] = (f, default_shape, dtypes[f])
+    else:
+        # if no fields specified and no value object keys, set a single default field
+        if not fields:
+            fields = [(namespace, default_shape, value_type)]
+        # check for fields defined as strings. assume they are all the same type as value.
+        else:
+            for i, f in enumerate(fields):
+                if isinstance(f, str):
+                    fields[i] = (f, default_shape, value_type)
+
+    # double check that everything looks how we want it.
+    assert len(fields), 'at least one field must be defined.'
+
+    assert all(isinstance(f, (list, tuple)) and len(f) == 3 for f in fields), (
+        'all fields must be a tuple of length 3: (name, shape, dtype)')
+
+    return fields, value_has_keys
+
+
+def _default_reducer(fields, value_has_keys, multi):
+    '''
+    Validate the fields passed and try to infer fields from incomplete info.
+
+    see `LambdaTransformer.__init__` for argument descriptions.
+
+    Arguments:
+    ----------
+    fields : list of tuples/str
+
+    value_type : dtype
+        the dtype of observation values
+
+    multi : bool
+        whether reduce should accept single or multiple values.
+
+    '''
+    fields = [f[0] for f in fields]
+    if value_has_keys:
+        if multi: # values will be a list of dicts
+            def reduce(values):
+                return {k: [v[k] for v in values] for k in fields}
+
+        else: # value will be a dict, or None
+            def reduce(value):
+                if not value:
+                    return {}
+                return {k: value[k] for k in fields if k in value}
+
+    else: # value will be some unspecified type
+        if len(fields) == 1:
+            field = fields[0]
+            # field = list(fields.keys())[0]
+            def reduce(value):
+                return {field: value}
+
+        else:
+            raise RuntimeError('For multi-field transformers, you must define '
+                               '`reduce`, the mapping from list of observation '
+                               'values to data dict.')
+    return reduce

--- a/pumpp/task/lambd.py
+++ b/pumpp/task/lambd.py
@@ -153,10 +153,9 @@ class LambdaTransformer(BaseTaskTransformer):
         intervals, values = ann.to_interval_values()
 
         # filter values that match query
-        intervals, values = zip(*[
-            (i, d) for i, d in zip(intervals, values)
-            if util.match_query(d, self.value_query)
-        ])
+        matches = [(i, d) for i, d in zip(intervals, values)
+                   if util.match_query(d, self.value_query)]
+        intervals, values = zip(*matches) if matches else ((), ())
 
         # get temporal slices, using one hot observation encoding
         idxs = np.eye(len(intervals))

--- a/pumpp/util.py
+++ b/pumpp/util.py
@@ -1,0 +1,90 @@
+import jams
+
+
+def match_query(data, query, strict_keys=False):
+    '''
+    Recursively determine if a datum matches a query.
+
+    data : any
+        the data to match the query against
+
+    query : same/similar to data
+        a set of tests matching the form of `data`.
+
+        If `query` is callable, it will be called with `data` as an argument.
+
+        If both `data` and `query` are dicts, each key in `query` will be tested against
+        each key in `data` recursively. If a key from `query` doesn't exist in `data`,
+        it will return False.
+
+        If both `data` and `query` are iterables, they will be compared elementwise.
+
+        If `query` is a set, it will check if `data` is a member of the set.
+
+        If none of those, it will compare using jams.core.match_query which performs
+        regex matching if both are strings, or tests for equality otherwise.
+
+    strict_keys : bool [optional]
+        Whether to throw an error if ``query`` has keys outside of ``data``.
+
+    Returns:
+    --------
+    bool representing whether the query matches.
+
+    Raises:
+    -------
+    ValueError :
+        If query is a dict, but data is not.
+
+        If strict_keys is True and query has keys outside data.
+
+        If query is an iterable, but data is not.
+
+        If query and data are both iterables, but not the same length.
+
+    Examples:
+    ---------
+    assert True  == match_query(5, 5)
+    assert True  == match_query(5, lambda x: x > 4)
+    assert True  == match_query({'a': 'abc', 'b': 'def'}, {'b': 'def'})
+    assert False == match_query({'a': 'abc', 'b': 'def'}, {'b': 'abc'})
+    assert True  == match_query({'a': 'abc', 'b': 'def'}, {'b': lambda x: 'd' in x})
+    assert False == match_query({'a': 'abc', 'b': 'def'}, {'a': 'abc', 'b': 'deg'})
+    assert True  == match_query([1, 2, 3, 4, 5], lambda x: 5 in x)
+    assert True  == match_query([1, 2, 3, 4, 5], [1, 2, 3, 4, lambda x: x in (5, 6, 7)])
+    assert True  == match_query('def', 'abc|def')
+    assert False == match_query({'b': 'def'}, {'b': 'def', 'c': 'ghi'})
+
+    '''
+
+    if query is None:
+        return True
+
+    if callable(query):
+        return query(data)
+
+    if isinstance(query, dict):
+        if isinstance(data, dict):
+            if strict_keys and not all(k in data for k in query):
+                raise ValueError('`query` has keys outside of `data` and '
+                                 '`strict_keys` was set.')
+
+            return all(k in data and match_query(data[k], query[k])
+                       for k in query)
+        else:
+            raise ValueError('`query` was a dict, but `data` was not.')
+
+    if isinstance(query, list):
+        if isinstance(data, list):
+            if len(data) != len(query):
+                raise ValueError('`query` and `data` must be a list of the '
+                                 'same length.')
+
+            return all(match_query(d, q) for d, q in zip(data, query))
+        else:
+            raise ValueError('`query` was an list, but `data` was not.')
+
+    if isinstance(query, set):
+        return data in query
+
+    return jams.core.match_query(data, query)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -5,7 +5,9 @@
 import pytest
 import numpy as np
 
+import jams
 import pumpp
+from pumpp.util import match_query
 
 from pumpp import ParameterError
 
@@ -52,3 +54,59 @@ def test_fill_value(dtype, fill):
 
     assert isinstance(v, dtype)
     assert v == fill or np.isnan(v) and np.isnan(fill)
+
+@pytest.mark.parametrize(
+    "expected,data,query",
+    [
+        (True,  5, None),
+        (True,  5, 5),
+        (True,  5, lambda x: x > 4),
+        (True,  {'a': 'abc', 'b': 'def'}, {'b': 'def'}),
+        (False, {'a': 'abc', 'b': 'def'}, {'b': 'abc'}),
+        (True,  {'a': 'abc', 'b': 'def'}, {'b': lambda x: 'd' in x}),
+        (False, {'a': 'abc', 'b': 'def'}, {'a': 'abc', 'b': 'deg'}),
+        (True,  [1, 2, 3, 4, 5], lambda x: 5 in x),
+        (True,  [1, 2, 3, 4, 5], [1, 2, 3, 4, lambda x: x in (5, 6, 7)]),
+        (True,  5, {5, 9, 10}),
+        (True,  'def', 'abc|def'),
+        (False, {'b': 'def'}, {'b': 'def', 'c': 'ghi'}), # has key outside
+        pytest.param(
+            False, 5, {'b': 'def', 'c': 'ghi'}, marks=xfail(raises=ValueError)),
+        pytest.param(
+            False, 5, ['def', 'ghi'], marks=xfail(raises=ValueError)),
+        pytest.param(
+            False, [5], ['def', 'ghi'], marks=xfail(raises=ValueError)), ])
+def test_match_query(expected, data, query):
+    assert expected  == match_query(data, query)
+
+@pytest.mark.parametrize(
+    "expected,data,query",
+    [(True, {'b': 'def', 'c': 'ghi'}, {'b': 'def'}),
+    pytest.param(
+        False, {'b': 'def'}, {'b': 'def', 'c': 'ghi'}, marks=xfail(raises=ValueError)), ])
+def test_match_query_strict(expected, data, query):
+    assert expected  == match_query(data, query, strict_keys=True)
+
+
+def test_get_dtype():
+    for namespace in jams.schema.__NAMESPACE__:
+        schema = jams.schema.namespace(namespace)
+        pumpp.task.lambd._get_dtype(schema)
+
+        val = schema['properties']['value']
+        try:
+            value_has_defined_keys = (
+                val['type'] == 'object' and 'properties' in val)
+        except KeyError:
+            value_has_keys = False
+
+        if value_has_keys:
+            for name, spec in val['properties'].items():
+                pumpp.task.lambd._get_dtype(spec)
+
+    # others that aren't tested:
+    assert np.object_ == pumpp.task.lambd._get_dtype({'type': ['number', 'string']})
+    assert np.object_ == pumpp.task.lambd._get_dtype({'enum': ['asdf', 5, 6]})
+    assert np.float64 == pumpp.task.lambd._get_dtype({'oneOf': [{'type': 'number'}, {'type': 'null'}]})
+    assert np.object_ == pumpp.task.lambd._get_dtype({'oneOf': [{'type': 'number'}, {'type': 'string'}]})
+    assert np.object_ == pumpp.task.lambd._get_dtype({})

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -98,9 +98,9 @@ def test_get_dtype():
             value_has_defined_keys = (
                 val['type'] == 'object' and 'properties' in val)
         except KeyError:
-            value_has_keys = False
+            value_has_defined_keys = False
 
-        if value_has_keys:
+        if value_has_defined_keys:
             for name, spec in val['properties'].items():
                 pumpp.task.lambd._get_dtype(spec)
 

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1057,7 +1057,7 @@ def test_task_beatpos_tail(SR, HOP_LENGTH, SPARSE):
 
 def test_task_key__encode_key_str(SPARSE):
     # Checks the helper function which does key string to encoding
-    
+
     # Check A:minor
     pitch_profile, tonic = _encode_key_str('A:minor', SPARSE)
     assert np.all(pitch_profile == np.array([1, 0, 1, 0, 1, 1, 0, 1, 1, 1, 0, 1]))
@@ -1096,8 +1096,8 @@ def test_task_key__encode_key_str(SPARSE):
         assert tonic == 12
     else:
         assert np.all(tonic == np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]))
- 
-        
+
+
 def test_task_key_fields(SPARSE):
     trans = pumpp.task.KeyTransformer(name='mykey', sparse=SPARSE)
 
@@ -1132,7 +1132,7 @@ def test_task_key_present(SR, HOP_LENGTH, SPARSE):
     trans = pumpp.task.KeyTransformer(name='key',
                                       sr=SR, hop_length=HOP_LENGTH,
                                       sparse=SPARSE)
-    
+
     output = trans.transform(jam)
 
     # Make sure we have the mask
@@ -1148,11 +1148,11 @@ def test_task_key_present(SR, HOP_LENGTH, SPARSE):
         _encode_key_str('D', SPARSE)[0],
         _encode_key_str('D:lydian', SPARSE)[0]
     ])
-    
+
     assert np.all(output['key/pitch_profile'] == np.repeat(pcp_true,
                                                            (SR * 2 // HOP_LENGTH),
                                                            axis=0))
-    
+
     for key in trans.fields:
         assert shape_match(output[key].shape[1:], trans.fields[key].shape)
         assert type_match(output[key].dtype, trans.fields[key].dtype)
@@ -1321,3 +1321,145 @@ def test_task_key_tag_absent(SR, HOP_LENGTH, SPARSE):
     for key in trans.fields:
         assert shape_match(output[key].shape[1:], trans.fields[key].shape)
         assert type_match(output[key].dtype, trans.fields[key].dtype)
+
+
+def _sampled_scaper_event(role, **kw):
+    return dict(dict(
+        role=role,
+        label=role,
+        source_file=role + '/asdf.wav',
+        event_time=0,
+        event_duration=10,
+        source_time=10,
+        snr=0,
+        pitch_shift=None,
+        time_stretch=None,
+    ), **kw)
+
+def test_transform_scaper():
+
+    jam = jams.JAMS(file_metadata=dict(duration=6.0))
+
+    ann = jams.Annotation(namespace='scaper')
+
+    ann.append(time=0, duration=jam.file_metadata.duration, value=_sampled_scaper_event('background'))
+    ann.append(time=0, duration=1.0, value=_sampled_scaper_event('foreground', snr=-10))
+    ann.append(time=2, duration=1.0, value=_sampled_scaper_event('foreground', snr=-6))
+    ann.append(time=2, duration=1.0, value=_sampled_scaper_event('foreground', snr=-3))
+    ann.append(time=4, duration=1.0, value=_sampled_scaper_event('foreground', snr=-2))
+
+    jam.annotations.append(ann)
+
+    # test full field inference
+
+    trans = pumpp.task.LambdaTransformer(
+        name='scaper', namespace='scaper',
+        sr=1, hop_length=1)
+
+    expected_fields = {'{}/{}'.format(trans.name, f) for f in _sampled_scaper_event('')}
+
+    output = trans.transform(jam)
+    assert set(output) == expected_fields | {'{}/{}'.format(trans.name, '_valid')}
+    assert not isinstance(output[tuple(expected_fields)[0]][0][0], list)
+
+    # test select field inference
+
+    fields = ['snr', 'label']
+    trans = pumpp.task.LambdaTransformer(
+        name='scaper', namespace='scaper',
+        fields=fields,
+        sr=1, hop_length=1)
+
+    expected_fields = {'{}/{}'.format(trans.name, f) for f in fields}
+
+    output = trans.transform(jam)
+    assert set(output) == expected_fields | {'{}/{}'.format(trans.name, '_valid')}
+
+    # test query
+
+    trans = pumpp.task.LambdaTransformer(
+        name='scaper', namespace='scaper',
+        fields=('role', 'snr'), query={'role': 'foreground'},
+        sr=1, hop_length=1, sample_index=-1)
+
+    output = trans.transform(jam)
+    role_null = pumpp.task.base.fill_value(trans.fields['scaper/role'].dtype)
+
+
+    roles = output['scaper/role'][0]
+    role_null = np.array(role_null, dtype=roles.dtype)
+    queried_roles = set(roles[roles != role_null])
+    assert queried_roles == {'foreground'}
+    assert output['scaper/snr'][0][2] == -3, 'the last observation was not taken.'
+
+    # test multi
+
+    trans = pumpp.task.LambdaTransformer(
+        name='scaper', namespace='scaper',
+        fields=('snr'),
+        query={'role': 'foreground'},
+        multi=True,
+        sr=1, hop_length=1)
+
+    output = trans.transform(jam)
+    print(output['scaper/snr'], output['scaper/snr'].shape, output['scaper/snr'][0][0].ndim)
+    assert output['scaper/snr'][0][0].ndim
+
+    # test reduce
+
+    trans = pumpp.task.LambdaTransformer(
+        name='scaper', namespace='scaper',
+        fields=('snr',),
+        query={'role': 'foreground'},
+        multi=True,
+        reduce=lambda events: {
+            'snr': np.mean([e['snr'] for e in events]),
+        },
+        sr=1, hop_length=1)
+
+    output = trans.transform(jam)
+    assert not output['scaper/snr'][0][0].ndim, 'there are still multiple elements per interval.'
+    assert output['scaper/snr'][0][2] == -4.5, 'field was not aggregated'
+
+
+def test_task_lambda_arbitrary(SR, HOP_LENGTH):
+    jam = jams.JAMS(file_metadata=dict(duration=4.0))
+
+    ann = jams.Annotation(namespace='tag_audioset')
+
+    ann.append(time=0, duration=1.0, value="Bird")
+    ann.append(time=1.0, duration=1, value="Bow-wow")
+    ann.append(time=1.5, duration=1.5, value="Bird")
+    ann.append(time=3, duration=1.0, value='Theremin')
+
+    jam.annotations.append(ann)
+
+    # test basic
+    trans = pumpp.task.LambdaTransformer(
+        name='auds', namespace='tag_audioset',
+        sr=1, hop_length=1)
+
+    KEY = 'auds/tag_audioset'
+    assert set(trans.fields) == {KEY}
+
+    output = trans.transform(jam)
+    assert np.all(output[KEY][0] == np.array(['Bird', 'Bird', 'Bird', 'Theremin']))
+
+    # test multi
+    trans = pumpp.task.LambdaTransformer(
+        name='auds', namespace='tag_audioset',
+        sr=1, hop_length=1, multi=True)
+
+    output = trans.transform(jam)
+    expected = np.array([['Bird'], ['Bow-wow', 'Bird'], ['Bird'], ['Theremin']])
+    assert np.all(a == b for a, b in zip(output[KEY][0], expected))
+
+    # test reduce
+    trans = pumpp.task.LambdaTransformer(
+        name='auds', namespace='tag_audioset',
+        sr=1, hop_length=1, multi=True, reduce=lambda vals: {
+            'tag_audioset': ','.join(vals)
+        })
+
+    output = trans.transform(jam)
+    assert np.all(output[KEY][0] == np.array(['Bird', 'Bow-wow,Bird', 'Bird', 'Theremin']))

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1383,8 +1383,7 @@ def test_transform_scaper():
         sr=1, hop_length=1, sample_index=-1)
 
     output = trans.transform(jam)
-    role_null = pumpp.task.base.fill_value(trans.fields['scaper/role'].dtype)
-
+    role_null = pumpp.task.lambd.fill_value(trans.fields['scaper/role'].dtype)
 
     roles = output['scaper/role'][0]
     role_null = np.array(role_null, dtype=roles.dtype)

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1360,7 +1360,7 @@ def test_transform_scaper():
 
     output = trans.transform(jam)
     assert set(output) == expected_fields | {'{}/{}'.format(trans.name, '_valid')}
-    assert not isinstance(output[tuple(expected_fields)[0]][0][0], list)
+    assert not output[tuple(expected_fields)[0]][0].ndim
 
     # test select field inference
 
@@ -1385,11 +1385,12 @@ def test_transform_scaper():
     output = trans.transform(jam)
     role_null = pumpp.task.lambd.fill_value(trans.fields['scaper/role'].dtype)
 
-    roles = output['scaper/role'][0]
+    roles = output['scaper/role']
     role_null = np.array(role_null, dtype=roles.dtype)
+    print(role_null, roles)
     queried_roles = set(roles[roles != role_null])
     assert queried_roles == {'foreground'}
-    assert output['scaper/snr'][0][2] == -3, 'the last observation was not taken.'
+    assert output['scaper/snr'][2] == -3, 'the last observation was not taken.'
 
     # test multi
 
@@ -1402,7 +1403,7 @@ def test_transform_scaper():
 
     output = trans.transform(jam)
     print(output['scaper/snr'], output['scaper/snr'].shape, output['scaper/snr'][0][0].ndim)
-    assert output['scaper/snr'][0][0].ndim
+    assert output['scaper/snr'][0].ndim
 
     # test reduce
 
@@ -1417,8 +1418,8 @@ def test_transform_scaper():
         sr=1, hop_length=1)
 
     output = trans.transform(jam)
-    assert not output['scaper/snr'][0][0].ndim, 'there are still multiple elements per interval.'
-    assert output['scaper/snr'][0][2] == -4.5, 'field was not aggregated'
+    assert not output['scaper/snr'][0].ndim, 'there are still multiple elements per interval.'
+    assert output['scaper/snr'][2] == -4.5, 'field was not aggregated'
 
 
 def test_task_lambda_arbitrary(SR, HOP_LENGTH):
@@ -1442,7 +1443,7 @@ def test_task_lambda_arbitrary(SR, HOP_LENGTH):
     assert set(trans.fields) == {KEY}
 
     output = trans.transform(jam)
-    assert np.all(output[KEY][0] == np.array(['Bird', 'Bird', 'Bird', 'Theremin']))
+    assert np.all(output[KEY] == np.array(['Bird', 'Bird', 'Bird', 'Theremin']))
 
     # test multi
     trans = pumpp.task.LambdaTransformer(
@@ -1451,7 +1452,7 @@ def test_task_lambda_arbitrary(SR, HOP_LENGTH):
 
     output = trans.transform(jam)
     expected = np.array([['Bird'], ['Bow-wow', 'Bird'], ['Bird'], ['Theremin']])
-    assert np.all(a == b for a, b in zip(output[KEY][0], expected))
+    assert np.all(a == b for a, b in zip(output[KEY], expected))
 
     # test reduce
     trans = pumpp.task.LambdaTransformer(
@@ -1461,4 +1462,4 @@ def test_task_lambda_arbitrary(SR, HOP_LENGTH):
         })
 
     output = trans.transform(jam)
-    assert np.all(output[KEY][0] == np.array(['Bird', 'Bow-wow,Bird', 'Bird', 'Theremin']))
+    assert np.all(output[KEY] == np.array(['Bird', 'Bow-wow,Bird', 'Bird', 'Theremin']))


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
This adds a general purpose transformer that can be used to load and transform arbitrary observations with Pump. 

I built this for the purpose of extracting Scaper annotations, but it's not Scaper specific.

Here's a super simple example:

```python
trans = pumpp.task.LambdaTransformer(
        name='scaper', namespace='scaper',
        fields=['snr', 'label'], 
        query={'role': 'foreground'})
```

Assuming a 5 second sample with a single 1 second event 2 seconds in, the data dict would look like this:
```python
{
    'scaper/snr': [np.nan, np.nan, 10, np.nan, np.nan],
    'scaper/label': ['', '', 'something', '', '']
}
```

#### Filtering Observations
`query` can be used flexibly with a wide range of values. The type of query should roughly match the observation values and is run recursively through dicts and lists. So if the observation is a dict and you want to query based on keys, you build it as a dict with keys matching `value`. If `value` is a list and you want to condition element-wise, then make `query` a list. If `value` is a single string then use a string. You can also use a set to check membership for hashable types. 

At any point, you can set it as a callable and it will pass the data up to that point.

It will will fail if any conditions are False.

Here are some valid query examples:
```python
query={'label': 'AAA|BBB'} # either AAA or BBB
query={'label': lambda label: 'A' in label, 'role': 'foreground'} # arbitrary condition
query={'pitch_shift': lambda pitch: pitch and pitch > 3} # whatever you want
query={'pitch_shift': {1, 2}} # pitch_shift is in set
query=lambda d: d['pitch_shift'] == -3 or 'Thunk' in d['label'] # callable gets the full dict

# Or say observation values are just strings
query=lambda label: 'Dog' in label
query={'Dog bark', 'Hum', 'Honk'} # label is in set
query='[^0-9]+'

# Or a list field of shape (None, 4,)
query=[5, 6, lambda x: x // 2 < 25, {8, 9, 10}] # mix and match
```

#### Aggregating interval windows
And you can have a bit more control. `reduce(x)` is iteratively fed a list of all the events within each hop window interval.
```python
trans = pumpp.task.LambdaTransformer(
        name='scaper', namespace='scaper',
        fields=[
            'label', # from schema
            ('mean_time_stretch', (None,1), np.float_), # custom field
            ('all_time_stretch', (None,None), np.float_), # variable number of events
        ], 
        query={'role': 'foreground'},
        multi=True, reduce=lambda events: {
            'label': ','.join(set(e['label'] for e in events)),
            'mean_time_stretch': np.mean([e['time_stretch'] for e in events]),
            'all_time_stretch': [e['time_stretch'] for e in events],
        })
```

#### real life
And finally, here's how I'm currently using it:

```python
pumpp.task.LambdaTransformer(
    'scaper', 'scaper',
    ['snr', 'label', 'source_file', ('fault', (None, 1), np.bool_)],
    query={'label': fault_label},
    reduce=lambda e: dict(e or {}, fault=e and ~np.isnan(e['snr']))
)
```

### Any other comments?
As of right now, the `all_time_stretch` field won't work with a slicer because all `None` fields are interpreted as a time dimension. I see how this makes sense for the `structure` transformer. I'm not sure how to reconcile it with returning array values. Maybe it's really not necessary ever, but part of my thinks it would be a nice option to have (returning an array for each interval) if we want to support as many use cases as possible.

This could also probably use some more safeguards preventing ppl from doing bad things, but atm I'm not sure what those would be so for now, I think it's okay to leave things open ended.