### PR TITLE
added option to use `tensorflow.keras`

### DIFF
--- a/pumpp/feature/base.py
+++ b/pumpp/feature/base.py
@@ -116,8 +116,10 @@ class FeatureExtractor(Scope):
             field keys.
         '''
 
-        if api == 'keras':
+        if api in ('k', 'keras'):
             return self.layers_keras()
+        elif api in ('tf.keras', 'tensorflow.keras', 'tfk'):
+            return self.layers_tfkeras()
         elif api in ('tf', 'tensorflow'):
             return self.layers_tensorflow()
         else:
@@ -135,6 +137,17 @@ class FeatureExtractor(Scope):
 
     def layers_keras(self):
         from keras.layers import Input
+
+        L = dict()
+        for key in self.fields:
+            L[key] = Input(name=key,
+                           shape=self.fields[key].shape,
+                           dtype=np.dtype(self.fields[key].dtype).name)
+
+        return L
+
+    def layers_tfkeras(self):
+        from tensorflow.keras.layers import Input
 
         L = dict()
         for key in self.fields:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -213,6 +213,10 @@ def test_pump_layers(sr, hop_length):
         for d1, d2 in zip(L1[k].shape, L2[k].shape):
             assert str(d1) == str(d2)
 
+    # test other input layers
+    P.layers('tf.keras')
+    P.layers('tf')
+
 
 def test_pump_str(sr, hop_length):
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
I added a method to build `tensorflow.keras` from a pumpp.

```python
import tensorflow.keras.layers as tfkl
...
input_ = pump.layers('tf.keras')[INPUT_NAME]
```