### PR TITLE
skip over pre-computed ops

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- encoding: utf-8 -*-
 '''Miscellaneous utility tests'''
-
 import pytest
 import numpy as np
 
@@ -258,3 +257,48 @@ def test_pump_repr_html(sr, hop_length):
     pump = pumpp.Pump(*ops)
 
     assert isinstance(pump._repr_html_(), str)
+
+
+def test_pump_skip(sr, hop_length, tmp_path):
+    ops = [pumpp.feature.STFT(name='stft', sr=sr,
+                              hop_length=hop_length,
+                              n_fft=2*hop_length),
+
+           pumpp.feature.Tempogram(name='tempo', sr=sr,
+                                   win_length=384,
+                                   hop_length=hop_length),
+
+           pumpp.task.BeatTransformer(name='beat', sr=sr,
+                                      hop_length=hop_length)]
+
+    audio_f = 'tests/data/test.ogg'
+    jam_f = 'tests/data/test.jams'
+    KEY = 'tempo/tempogram'
+    SENTINEL = (None,)
+    data = {KEY: SENTINEL}
+
+    P = pumpp.Pump(*ops)
+    fields = set(P.fields)
+
+    get_valid_fields = lambda x: {f for f in set(x) if not f.endswith('_valid')}
+
+    # see if existing keys are skipped
+    X = P.transform(audio_f, data=dict(data))
+    assert X[KEY] is SENTINEL, 'field was overwritten'
+    assert get_valid_fields(X) == fields
+
+    # make sure fields are computed normally
+    X = P.transform(audio_f)
+    assert X[KEY] is not SENTINEL, 'field was not computed'
+    assert get_valid_fields(X) == fields
+
+    # see if loading audio is skipped if we don't need it
+
+    feature_ops = [op for op in P.ops if isinstance(op, pumpp.FeatureExtractor)]
+    data = {k: SENTINEL for op in feature_ops for k in op.fields}
+
+    X = P.transform(None, jam_f, data=data)
+    assert all(X[k] is SENTINEL
+               for op in feature_ops
+               for k in op.fields), 'field should not have been computed'
+    assert get_valid_fields(X) == fields


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/bmcfee/pumpp/blob/master/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
<!-- Example: Fixes #123 -->

Addresses #120 

#### What does this implement/fix? Explain your changes.
 ##### Pumps will not recompute fields already in the data dict:

now you can pass a data dict to `transform(data={})` and if all of an op's fields are in that dict, it will skip that op. Meaning that you can do:

```python
pump.transform(audio_f, jam_f, data=crema.util.load_h5(h5_f))
```

and if everything is already computed in the h5 file, no ops will be performed.

 ##### Audio/Jams files will only be loaded if they're needed

If your pump only has task transformers, or if all feature extractors were already computed, `transform` will not attempt to load audio. The same is for the inverse w/ jams. Now things can go quicker :)
